### PR TITLE
Walrus bindings

### DIFF
--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -612,8 +612,7 @@ def _get_bindings_for_await(node):
         # the grammar constrains where yield expressions can occur
         Await(expr value)
     """
-    return
-    yield
+    yield from get_bindings(node.value)
 
 
 @get_bindings.register(ast.Yield)
@@ -623,8 +622,8 @@ def _get_bindings_for_yield(node):
 
         Yield(expr? value)
     """
-    return
-    yield
+    if node.value is not None:
+        yield from get_bindings(node.value)
 
 
 @get_bindings.register(ast.YieldFrom)
@@ -634,8 +633,7 @@ def _get_bindings_for_yield_from(node):
 
         YieldFrom(expr value)
     """
-    return
-    yield
+    yield from get_bindings(node.value)
 
 
 @get_bindings.register(ast.Compare)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -542,10 +542,16 @@ def _get_bindings_for_list_comp(node):
     """
     ..code:: python
 
+        comprehension = (expr target, expr iter, expr* ifs, int is_async)
         ListComp(expr elt, comprehension* generators)
     """
     for generator in node.generators:
+        yield from get_bindings(generator.iter)
         yield from _flatten_target(generator.target)
+        for condition in generator.ifs:
+            yield from get_bindings(condition)
+
+    yield from get_bindings(node.elt)
 
 
 @get_bindings.register(ast.SetComp)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -365,8 +365,10 @@ def _get_bindings_for_assert(node):
         Assert(expr test, expr? msg)
 
     """
-    return
-    yield
+    yield from get_bindings(node.test)
+
+    if node.msg is not None:
+        yield from get_bindings(node.msg)
 
 
 @get_bindings.register(ast.Import)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -318,8 +318,11 @@ def _get_bindings_for_raise(node):
 
         Raise(expr? exc, expr? cause)
     """
-    return
-    yield
+    if node.cause is not None:
+        yield from get_bindings(node.cause)
+
+    if node.exc is not None:
+        yield from get_bindings(node.exc)
 
 
 @get_bindings.register(ast.Try)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -487,8 +487,7 @@ def _get_bindings_for_unary_op(node):
 
         UnaryOp(unaryop op, expr operand)
     """
-    return
-    yield
+    yield from get_bindings(node.operand)
 
 
 @get_bindings.register(ast.Lambda)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -453,8 +453,8 @@ def _get_bindings_for_bool_op(node):
         # expr
         BoolOp(boolop op, expr* values)
     """
-    return
-    yield
+    for expr in node.values:
+        yield from get_bindings(expr)
 
 
 @get_bindings.register(ast.NamedExpr)
@@ -476,8 +476,8 @@ def _get_bindings_for_bin_op(node):
 
         BinOp(expr left, operator op, expr right)
     """
-    return
-    yield
+    yield from get_bindings(node.left)
+    yield from get_bindings(node.right)
 
 
 @get_bindings.register(ast.UnaryOp)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -519,8 +519,11 @@ def _get_bindings_for_dict(node):
 
         Dict(expr* keys, expr* values)
     """
-    return
-    yield
+    for key, value in zip(node.keys, node.values):
+        if key is not None:
+            yield from get_bindings(key)
+        if value is not None:
+            yield from get_bindings(value)
 
 
 @get_bindings.register(ast.Set)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -497,8 +497,7 @@ def _get_bindings_for_lambda(node):
 
         Lambda(arguments args, expr body)
     """
-    return
-    yield
+    yield from _get_bindings_from_arguments(node.args)
 
 
 @get_bindings.register(ast.IfExp)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -93,6 +93,15 @@ def _get_bindings_for_class_def(node):
             expr* decorator_list,
         )
     """
+    for decorator in node.decorator_list:
+        yield from get_bindings(decorator)
+
+    for base in node.bases:
+        yield from get_bindings(base)
+
+    for keyword in node.keywords:
+        yield from get_bindings(keyword.value)
+
     yield node.name
 
 

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -185,6 +185,8 @@ def _get_bindings_for_assign(node):
 
         Assign(expr* targets, expr value, string? type_comment)
     """
+    yield from get_bindings(node.value)
+
     for target in node.targets:
         yield from _flatten_target(target)
 
@@ -196,6 +198,8 @@ def _get_bindings_for_aug_assign(node):
 
         AugAssign(expr target, operator op, expr value)
     """
+    yield from get_bindings(node.value)
+
     yield from _flatten_target(node.target)
 
 
@@ -208,6 +212,11 @@ def _get_bindings_for_ann_assign(node):
         AnnAssign(expr target, expr annotation, expr? value, int simple)
 
     """
+    yield from get_bindings(node.annotation)
+
+    if node.value is not None:
+        yield from get_bindings(node.value)
+
     yield from _flatten_target(node.target)
 
 

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -301,6 +301,8 @@ def _get_bindings_for_with(node):
         AsyncWith(withitem* items, stmt* body, string? type_comment)
     """
     for item in node.items:
+        yield from get_bindings(item.context_expr)
+
         if item.optional_vars:
             yield from _flatten_target(item.optional_vars)
 

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -783,8 +783,8 @@ def _get_bindings_for_list(node):
 
         List(expr* elts, expr_context ctx)
     """
-    return
-    yield
+    for elt in node.elts:
+        yield from get_bindings(elt)
 
 
 @get_bindings.register(ast.Tuple)
@@ -795,5 +795,5 @@ def _get_bindings_for_tuple(node):
         Tuple(expr* elts, expr_context ctx)
 
     """
-    return
-    yield
+    for elt in node.elts:
+        yield from get_bindings(elt)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -279,6 +279,8 @@ def _get_bindings_for_if(node):
 
         If(expr test, stmt* body, stmt* orelse)
     """
+    yield from get_bindings(node.test)
+
     for stmt in node.body:
         yield from get_bindings(stmt)
 

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -507,8 +507,9 @@ def _get_bindings_for_if_exp(node):
 
         IfExp(expr test, expr body, expr orelse)
     """
-    return
-    yield
+    yield from get_bindings(node.test)
+    yield from get_bindings(node.body)
+    yield from get_bindings(node.orelse)
 
 
 @get_bindings.register(ast.Dict)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -579,7 +579,13 @@ def _get_bindings_for_dict_comp(node):
         DictComp(expr key, expr value, comprehension* generators)
     """
     for generator in node.generators:
+        yield from get_bindings(generator.iter)
         yield from _flatten_target(generator.target)
+        for condition in generator.ifs:
+            yield from get_bindings(condition)
+
+    yield from get_bindings(node.key)
+    yield from get_bindings(node.value)
 
 
 @get_bindings.register(ast.GeneratorExp)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -655,10 +655,16 @@ def _get_bindings_for_call(node):
     """
     ..code:: python
 
+        keyword = (identifier? arg, expr value)
         Call(expr func, expr* args, keyword* keywords)
     """
-    return
-    yield
+    yield from get_bindings(node.func)
+
+    for arg in node.args:
+        yield from get_bindings(arg)
+
+    for kwarg in node.keywords:
+        yield from get_bindings(kwarg.value)
 
 
 @get_bindings.register(ast.FormattedValue)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -245,6 +245,8 @@ def _get_bindings_for_for(node):
             string? type_comment,
         )
     """
+    yield from get_bindings(node.iter)
+
     yield from _flatten_target(node.target)
 
     for stmt in node.body:

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -596,7 +596,12 @@ def _get_bindings_for_generator_exp(node):
         GeneratorExp(expr elt, comprehension* generators)
     """
     for generator in node.generators:
+        yield from get_bindings(generator.iter)
         yield from _flatten_target(generator.target)
+        for condition in generator.ifs:
+            yield from get_bindings(condition)
+
+    yield from get_bindings(node.elt)
 
 
 @get_bindings.register(ast.Await)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -674,8 +674,7 @@ def _get_bindings_for_formatted_value(node):
 
         FormattedValue(expr value, int? conversion, expr? format_spec)
     """
-    return
-    yield
+    yield from get_bindings(node.value)
 
 
 @get_bindings.register(ast.JoinedStr)
@@ -685,8 +684,8 @@ def _get_bindings_for_joined_str(node):
 
         JoinedStr(expr* values)
     """
-    return
-    yield
+    for value in node.values:
+        yield from get_bindings(value)
 
 
 @get_bindings.register(ast.Constant)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -559,10 +559,16 @@ def _get_bindings_for_set_comp(node):
     """
     ..code:: python
 
+        comprehension = (expr target, expr iter, expr* ifs, int is_async)
         SetComp(expr elt, comprehension* generators)
     """
     for generator in node.generators:
+        yield from get_bindings(generator.iter)
         yield from _flatten_target(generator.target)
+        for condition in generator.ifs:
+            yield from get_bindings(condition)
+
+    yield from get_bindings(node.elt)
 
 
 @get_bindings.register(ast.DictComp)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -263,6 +263,8 @@ def _get_bindings_for_while(node):
 
         While(expr test, stmt* body, stmt* orelse)
     """
+    yield from get_bindings(node.test)
+
     for stmt in node.body:
         yield from get_bindings(stmt)
 

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -533,8 +533,8 @@ def _get_bindings_for_set(node):
 
         Set(expr* elts)
     """
-    return
-    yield
+    for elt in node.elts:
+        yield from get_bindings(elt)
 
 
 @get_bindings.register(ast.ListComp)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -444,6 +444,17 @@ def _get_bindings_for_control_flow(node):
     yield
 
 
+@get_bindings.register(ast.NamedExpr)
+def _get_bindings_for_named_expr(node):
+    """
+    ..code:: python
+
+        NamedExpr(expr target, expr value)
+    """
+    yield from get_bindings(node.value)
+    yield from _flatten_target(node.target)
+
+
 @get_bindings.register(ast.BoolOp)
 def _get_bindings_for_bool_op(node):
     """
@@ -455,17 +466,6 @@ def _get_bindings_for_bool_op(node):
     """
     for expr in node.values:
         yield from get_bindings(expr)
-
-
-@get_bindings.register(ast.NamedExpr)
-def _get_bindings_for_named_expr(node):
-    """
-    ..code:: python
-
-        NamedExpr(expr target, expr value)
-    """
-    yield from _flatten_target(node.target)
-    yield from get_bindings(node.value)
 
 
 @get_bindings.register(ast.BinOp)

--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -645,8 +645,9 @@ def _get_bindings_for_compare(node):
         # x < 4 < 3 and (x < 4) < 3
         Compare(expr left, cmpop* ops, expr* comparators)
     """
-    return
-    yield
+    yield from get_bindings(node.left)
+    for comparator in node.comparators:
+        yield from get_bindings(comparator)
 
 
 @get_bindings.register(ast.Call)

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1056,9 +1056,29 @@ def test_set_comp_bindings():
     """
     ..code:: python
 
+        comprehension = (expr target, expr iter, expr* ifs, int is_async)
         SetComp(expr elt, comprehension* generators)
     """
-    pass
+    node = _parse("{item for item in iterator if condition(item)}")
+    assert list(get_bindings(node)) == ["item"]
+
+
+@walrus_operator
+def test_set_comp_bindings_walrus_target():
+    node = _parse("{( a:= item) for item in iterator if condition(item)}")
+    assert list(get_bindings(node)) == ["item", "a"]
+
+
+@walrus_operator
+def test_set_comp_bindings_walrus_iter():
+    node = _parse("{item for item in (it := iterator) if condition(item)}")
+    assert list(get_bindings(node)) == ["it", "item"]
+
+
+@walrus_operator
+def test_set_comp_bindings_walrus_condition():
+    node = _parse("{item for item in iterator if (c := condition(item))}")
+    assert list(get_bindings(node)) == ["item", "c"]
 
 
 def test_dict_comp_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -672,7 +672,25 @@ def test_assert_bindings():
         Assert(expr test, expr? msg)
 
     """
-    pass
+    node = _parse("assert condition()")
+    assert list(get_bindings(node)) == []
+
+
+def test_assert_bindings_with_message():
+    node = _parse('assert condition(), "message"')
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_assert_bindings_walrus_condition():
+    node = _parse("assert (result := condition())")
+    assert list(get_bindings(node)) == ["result"]
+
+
+@walrus_operator
+def test_assert_bindings_walrus_message():
+    node = _parse('assert condition, (message := "message")')
+    assert list(get_bindings(node)) == ["message"]
 
 
 def test_import_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -759,14 +759,37 @@ def test_nonlocal_bindings_multiple():
     assert list(get_bindings(node)) == ["a", "b"]
 
 
-def test_control_flow_bindings():
+def test_pass_bindings():
     """
     ..code:: python
 
-        Pass | Break | Continue
+        Pass
 
     """
-    pass
+    node = _parse("pass")
+    assert list(get_bindings(node)) == []
+
+
+def test_break_bindings():
+    """
+    ..code:: python
+
+        Break
+
+    """
+    node = _parse("break")
+    assert list(get_bindings(node)) == []
+
+
+def test_continue_bindings():
+    """
+    ..code:: python
+
+        Continue
+
+    """
+    node = _parse("continue")
+    assert list(get_bindings(node)) == []
 
 
 def test_bool_op_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -885,7 +885,14 @@ def test_unary_op_bindings():
 
         UnaryOp(unaryop op, expr operand)
     """
-    pass
+    node = _parse("-a")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_unary_op_bindings_walrus():
+    node = _parse("-(a := b)")
+    assert list(get_bindings(node)) == ["a"]
 
 
 def test_lambda_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -458,7 +458,28 @@ def test_if_bindings():
 
         If(expr test, stmt* body, stmt* orelse)
     """
-    pass
+    node = _parse(
+        """
+        if predicate_one():
+            a = 1
+        elif predicate_two():
+            b = 2
+        else:
+            c = 3
+        """
+    )
+    assert list(get_bindings(node)) == ["a", "b", "c"]
+
+
+@walrus_operator
+def test_if_bindings_walrus_test():
+    node = _parse(
+        """
+        if (result := predicate()):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["result"]
 
 
 def test_with_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1134,7 +1134,26 @@ def test_generator_exp_bindings():
 
         GeneratorExp(expr elt, comprehension* generators)
     """
-    pass
+    node = _parse("(item for item in iterator if condition(item))")
+    assert list(get_bindings(node)) == ["item"]
+
+
+@walrus_operator
+def test_generator_exp_bindings_walrus_target():
+    node = _parse("(( a:= item) for item in iterator if condition(item))")
+    assert list(get_bindings(node)) == ["item", "a"]
+
+
+@walrus_operator
+def test_generator_exp_bindings_walrus_iter():
+    node = _parse("(item for item in (it := iterator) if condition(item))")
+    assert list(get_bindings(node)) == ["it", "item"]
+
+
+@walrus_operator
+def test_generator_exp_bindings_walrus_condition():
+    node = _parse("(item for item in iterator if (c := condition(item)))")
+    assert list(get_bindings(node)) == ["item", "c"]
 
 
 def test_await_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -368,7 +368,26 @@ def test_for_bindings():
             string? type_comment,
         )
     """
-    pass
+    node = _parse(
+        """
+        for i in range(10):
+            a += i
+        else:
+            b = 4
+        """
+    )
+    assert list(get_bindings(node)) == ["i", "a", "b"]
+
+
+@walrus_operator
+def test_for_bindings_walrus():
+    node = _parse(
+        """
+        for i in (r := range(10)):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["r", "i"]
 
 
 def test_async_for_bindings():
@@ -383,7 +402,26 @@ def test_async_for_bindings():
             string? type_comment,
         )
     """
-    pass
+    node = _parse(
+        """
+        async for i in range(10):
+            a += i
+        else:
+            b = 4
+        """
+    )
+    assert list(get_bindings(node)) == ["i", "a", "b"]
+
+
+@walrus_operator
+def test_async_for_bindings_walrus():
+    node = _parse(
+        """
+        async for i in (r := range(10)):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["r", "i"]
 
 
 def test_while_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -805,6 +805,28 @@ def test_bool_op_bindings():
 
 
 @walrus_operator
+def test_named_expr_bindings():
+    """
+    ..code:: python
+
+        NamedExpr(expr target, expr value)
+    """
+    node = _parse("(a := b)")
+    assert list(get_bindings(node)) == ["a"]
+
+
+@walrus_operator
+def test_named_expr_bindings_recursive():
+    """
+    ..code:: python
+
+        NamedExpr(expr target, expr value)
+    """
+    node = _parse("(a := (b := (c := d)))")
+    assert list(get_bindings(node)) == ["c", "b", "a"]
+
+
+@walrus_operator
 def test_bool_op_bindings_walrus_left():
     node = _parse("(left := a) and b")
     assert list(get_bindings(node)) == ["left"]
@@ -826,15 +848,6 @@ def test_bool_op_bindings_walrus_both():
 def test_bool_op_bindings_walrus_multiple():
     node = _parse("(a := 1) and (b := 2) and (c := 3)")
     assert list(get_bindings(node)) == ["a", "b", "c"]
-
-
-def test_named_expr_bindings():
-    """
-    ..code:: python
-
-        NamedExpr(expr target, expr value)
-    """
-    pass
 
 
 def test_bin_op_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1232,9 +1232,37 @@ def test_call_bindings():
     """
     ..code:: python
 
+        keyword = (identifier? arg, expr value)
         Call(expr func, expr* args, keyword* keywords)
     """
-    pass
+    node = _parse("fun(arg, *args, kwarg=kwarg, **kwargs)")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_call_bindings_walrus_function():
+    node = _parse("(f := fun)()")
+    assert list(get_bindings(node)) == ["f"]
+
+
+@walrus_operator
+def test_call_bindings_walrus_args():
+    node = _parse(
+        """
+        fun(
+            (arg_binding := arg),
+            *(args_binding := args),
+            kwarg=(kwarg_binding := kwarg),
+            **(kwargs_binding := kwargs),
+        )
+        """
+    )
+    assert list(get_bindings(node)) == [
+        "arg_binding",
+        "args_binding",
+        "kwarg_binding",
+        "kwargs_binding",
+    ]
 
 
 def test_formatted_value_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -298,6 +298,12 @@ def test_assign_bindings_list_star():
     assert list(get_bindings(node)) == ["first", "rest"]
 
 
+@walrus_operator
+def test_assign_bindings_walrus_value():
+    node = _parse("a = (b := c)")
+    assert list(get_bindings(node)) == ["b", "a"]
+
+
 def test_aug_assign_bindings():
     """
     ..code:: python
@@ -306,6 +312,17 @@ def test_aug_assign_bindings():
     """
     node = _parse("a += b")
     assert list(get_bindings(node)) == ["a"]
+
+
+def test_aug_assign_bindings_attribute():
+    node = _parse("obj.attr /= value")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_aug_assign_bindings_walrus_value():
+    node = _parse("a ^= (b := c)")
+    assert list(get_bindings(node)) == ["b", "a"]
 
 
 def test_ann_assign_bindings():
@@ -318,6 +335,24 @@ def test_ann_assign_bindings():
     """
     node = _parse("a: int = b")
     assert list(get_bindings(node)) == ["a"]
+
+
+def test_ann_assign_bindings_no_value():
+    # TODO this expression doesn't technically bind `a`.
+    node = _parse("a: int")
+    assert list(get_bindings(node)) == ["a"]
+
+
+@walrus_operator
+def test_ann_assign_bindings_walrus_value():
+    node = _parse("a: int = (b := c)")
+    assert list(get_bindings(node)) == ["b", "a"]
+
+
+@walrus_operator
+def test_ann_assign_bindings_walrus_type():
+    node = _parse("a: (a_type := int) = 4")
+    assert list(get_bindings(node)) == ["a_type", "a"]
 
 
 def test_for_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1087,7 +1087,45 @@ def test_dict_comp_bindings():
 
         DictComp(expr key, expr value, comprehension* generators)
     """
-    pass
+    node = _parse("{item[0]: item[1] for item in iterator if check(item)}")
+    assert list(get_bindings(node)) == ["item"]
+
+
+def test_dict_comp_bindings_unpack():
+    node = _parse("{key: value for key, value in iterator}")
+    assert list(get_bindings(node)) == ["key", "value"]
+
+
+@walrus_operator
+def test_dict_comp_bindings_walrus_key():
+    node = _parse(
+        "{(key := item[0]): item[1] for item in iterator if check(item)}"
+    )
+    assert list(get_bindings(node)) == ["item", "key"]
+
+
+@walrus_operator
+def test_dict_comp_bindings_walrus_value():
+    node = _parse(
+        "{item[0]: (value := item[1]) for item in iterator if check(item)}"
+    )
+    assert list(get_bindings(node)) == ["item", "value"]
+
+
+@walrus_operator
+def test_dict_comp_bindings_walrus_iter():
+    node = _parse(
+        "{item[0]: item[1] for item in (it := iterator) if check(item)}"
+    )
+    assert list(get_bindings(node)) == ["it", "item"]
+
+
+@walrus_operator
+def test_dict_comp_bindings_walrus_condition():
+    node = _parse(
+        "{item[0]: item[1] for item in iterator if (c := check(item))}"
+    )
+    assert list(get_bindings(node)) == ["item", "c"]
 
 
 def test_generator_exp_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -977,6 +977,23 @@ def test_dict_bindings_unpack():
     node = _parse("{**values}")
     assert list(get_bindings(node)) == []
 
+@walrus_operator
+def test_dict_bindings_walrus_key():
+    node = _parse("{(key := genkey()): value}")
+    assert list(get_bindings(node)) == ["key"]
+
+
+@walrus_operator
+def test_dict_bindings_walrus_value():
+    node = _parse("{key: (value := genvalue())}")
+    assert list(get_bindings(node)) == ["value"]
+
+
+@walrus_operator
+def test_dict_bindings_walrus_unpack():
+    node = _parse("{key: value, **(rest := other)}")
+    assert list(get_bindings(node)) == ["rest"]
+
 
 def test_set_bindings():
     """

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -491,14 +491,13 @@ def test_with_bindings():
     node = _parse(
         """
         with A() as a:
-            a()
-            b()
+            b = 4
         """
     )
-    assert list(get_bindings(node)) == ["a"]
+    assert list(get_bindings(node)) == ["a", "b"]
 
 
-def test_with_requirements_bindings():
+def test_with_bindings_requirements_example():
     node = _parse(
         """
         with chdir(os.path.dirname(path)):
@@ -511,13 +510,101 @@ def test_with_requirements_bindings():
     assert list(get_bindings(node)) == ["requirements", "req"]
 
 
+def test_with_bindings_multiple():
+    node = _parse(
+        """
+        with A() as a, B() as b:
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["a", "b"]
+
+
+def test_with_bindings_unbound():
+    node = _parse(
+        """
+        with A():
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == []
+
+
+def test_with_bindings_tuple():
+    node = _parse(
+        """
+        with A() as (a, b):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["a", "b"]
+
+
+@walrus_operator
+def test_with_bindings_walrus():
+    node = _parse(
+        """
+        with (ctx := A()) as a:
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["ctx", "a"]
+
+
 def test_async_with_bindings():
     """
     ..code:: python
 
         AsyncWith(withitem* items, stmt* body, string? type_comment)
     """
-    pass
+    node = _parse(
+        """
+        async with A() as a:
+            b = 4
+        """
+    )
+    assert list(get_bindings(node)) == ["a", "b"]
+
+
+def test_async_with_bindings_multiple():
+    node = _parse(
+        """
+        async with A() as a, B() as b:
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["a", "b"]
+
+
+def test_async_with_bindings_unbound():
+    node = _parse(
+        """
+        async with A():
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == []
+
+
+def test_async_with_bindings_tuple():
+    node = _parse(
+        """
+        async with A() as (a, b):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["a", "b"]
+
+
+@walrus_operator
+def test_async_with_bindings_walrus():
+    node = _parse(
+        """
+        async with (ctx := A()) as a:
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["ctx", "a"]
 
 
 def test_raise_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -904,6 +904,24 @@ def test_lambda_bindings():
     pass
 
 
+@walrus_operator
+def test_lambda_bindings_walrus_default():
+    node = _parse("(lambda a, b = (b_binding := 2): None)")
+    assert list(get_bindings(node)) == ["b_binding"]
+
+
+@walrus_operator
+def test_lambda_bindings_walrus_kw_default():
+    node = _parse("(lambda *, kw1 = (kw1_binding := 1), kw2: None)")
+    assert list(get_bindings(node)) == ["kw1_binding"]
+
+
+@walrus_operator
+def test_lambda_bindings_walrus_body():
+    node = _parse("(lambda : (a := 1) + a)")
+    assert list(get_bindings(node)) == []
+
+
 def test_if_exp_bindings():
     """
     ..code:: python

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -759,15 +759,6 @@ def test_nonlocal_bindings_multiple():
     assert list(get_bindings(node)) == ["a", "b"]
 
 
-def test_expr_bindings():
-    """
-    ..code:: python
-
-        Expr(expr value)
-    """
-    pass
-
-
 def test_control_flow_bindings():
     """
     ..code:: python

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1027,9 +1027,29 @@ def test_list_comp_bindings():
     """
     ..code:: python
 
+        comprehension = (expr target, expr iter, expr* ifs, int is_async)
         ListComp(expr elt, comprehension* generators)
     """
-    pass
+    node = _parse("[item for item in iterator if condition(item)]")
+    assert list(get_bindings(node)) == ["item"]
+
+
+@walrus_operator
+def test_list_comp_bindings_walrus_target():
+    node = _parse("[( a:= item) for item in iterator if condition(item)]")
+    assert list(get_bindings(node)) == ["item", "a"]
+
+
+@walrus_operator
+def test_list_comp_bindings_walrus_iter():
+    node = _parse("[item for item in (it := iterator) if condition(item)]")
+    assert list(get_bindings(node)) == ["it", "item"]
+
+
+@walrus_operator
+def test_list_comp_bindings_walrus_condition():
+    node = _parse("[item for item in iterator if (c := condition(item))]")
+    assert list(get_bindings(node)) == ["item", "c"]
 
 
 def test_set_comp_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -735,7 +735,13 @@ def test_global_bindings():
 
         Global(identifier* names)
     """
-    pass
+    node = _parse("global name")
+    assert list(get_bindings(node)) == ["name"]
+
+
+def test_global_bindings_multiple():
+    node = _parse("global a, b")
+    assert list(get_bindings(node)) == ["a", "b"]
 
 
 def test_non_local_bindings():
@@ -744,7 +750,13 @@ def test_non_local_bindings():
 
         Nonlocal(identifier* names)
     """
-    pass
+    node = _parse("nonlocal name")
+    assert list(get_bindings(node)) == ["name"]
+
+
+def test_nonlocal_bindings_multiple():
+    node = _parse("nonlocal a, b")
+    assert list(get_bindings(node)) == ["a", "b"]
 
 
 def test_expr_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1218,7 +1218,14 @@ def test_compare_bindings():
         # x < 4 < 3 and (x < 4) < 3
         Compare(expr left, cmpop* ops, expr* comparators)
     """
-    pass
+    node = _parse("0 < value < 5")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_compare_bindings_walrus():
+    node = _parse("(a := 0) < (b := value) < (c := 5)")
+    assert list(get_bindings(node)) == ["a", "b", "c"]
 
 
 def test_call_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -928,7 +928,34 @@ def test_if_exp_bindings():
 
         IfExp(expr test, expr body, expr orelse)
     """
-    pass
+    node = _parse("subsequent() if predicate() else alternate()")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_if_exp_bindings_walrus_subsequent():
+    node = _parse("(a := subsequent()) if predicate() else alternate()")
+    assert list(get_bindings(node)) == ["a"]
+
+
+@walrus_operator
+def test_if_exp_bindings_walrus_predicate():
+    node = _parse("subsequent() if (a := predicate()) else alternate()")
+    assert list(get_bindings(node)) == ["a"]
+
+
+@walrus_operator
+def test_if_exp_bindings_walrus_alternate():
+    node = _parse("subsequent() if predicate() else (a := alternate())")
+    assert list(get_bindings(node)) == ["a"]
+
+
+@walrus_operator
+def test_if_exp_bindings_walrus():
+    node = _parse(
+        "(a := subsequent()) if (b := predicate()) else (c := alternate())"
+    )
+    assert list(get_bindings(node)) == ["b", "a", "c"]
 
 
 def test_dict_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -800,7 +800,32 @@ def test_bool_op_bindings():
         # expr
         BoolOp(boolop op, expr* values)
     """
-    pass
+    node = _parse("a and b")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_bool_op_bindings_walrus_left():
+    node = _parse("(left := a) and b")
+    assert list(get_bindings(node)) == ["left"]
+
+
+@walrus_operator
+def test_bool_op_bindings_walrus_right():
+    node = _parse("a or (right := b)")
+    assert list(get_bindings(node)) == ["right"]
+
+
+@walrus_operator
+def test_bool_op_bindings_walrus_both():
+    node = _parse("(left := a) and (right := b)")
+    assert list(get_bindings(node)) == ["left", "right"]
+
+
+@walrus_operator
+def test_bool_op_bindings_walrus_multiple():
+    node = _parse("(a := 1) and (b := 2) and (c := 3)")
+    assert list(get_bindings(node)) == ["a", "b", "c"]
 
 
 def test_named_expr_bindings():
@@ -819,7 +844,26 @@ def test_bin_op_bindings():
 
         BinOp(expr left, operator op, expr right)
     """
-    pass
+    node = _parse("a and b")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_bin_op_bindings_walrus_left():
+    node = _parse("(left := a) | b")
+    assert list(get_bindings(node)) == ["left"]
+
+
+@walrus_operator
+def test_bin_op_bindings_walrus_right():
+    node = _parse("a ^ (right := b)")
+    assert list(get_bindings(node)) == ["right"]
+
+
+@walrus_operator
+def test_bin_op_bindings_walrus_both():
+    node = _parse("(left := a) + (right := b)")
+    assert list(get_bindings(node)) == ["left", "right"]
 
 
 def test_unary_op_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -611,10 +611,32 @@ def test_raise_bindings():
     """
     ..code:: python
 
-
         Raise(expr? exc, expr? cause)
     """
-    pass
+    node = _parse("raise TypeError()")
+    assert list(get_bindings(node)) == []
+
+
+def test_raise_bindings_reraise():
+    node = _parse("raise")
+    assert list(get_bindings(node)) == []
+
+
+def test_raise_bindings_with_cause():
+    node = _parse("raise TypeError() from exc")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_raise_bindings_walrus():
+    node = _parse("raise (exc := TypeError())")
+    assert list(get_bindings(node)) == ["exc"]
+
+
+@walrus_operator
+def test_raise_bindings_walrus_in_cause():
+    node = _parse("raise TypeError() from (original := exc)")
+    assert list(get_bindings(node)) == ["original"]
 
 
 def test_try_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -977,6 +977,7 @@ def test_dict_bindings_unpack():
     node = _parse("{**values}")
     assert list(get_bindings(node)) == []
 
+
 @walrus_operator
 def test_dict_bindings_walrus_key():
     node = _parse("{(key := genkey()): value}")
@@ -1001,7 +1002,25 @@ def test_set_bindings():
 
         Set(expr* elts)
     """
-    pass
+    node = _parse("{a, b, c}")
+    assert list(get_bindings(node)) == []
+
+
+def test_set_bindings_unpack():
+    node = _parse("{a, b, *rest}")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_set_bindings_walrus():
+    node = _parse("{a, {b := genb()}, c}")
+    assert list(get_bindings(node)) == ["b"]
+
+
+@walrus_operator
+def test_set_bindings_walrus_unpack():
+    node = _parse("{a, b, *(rest := other)}")
+    assert list(get_bindings(node)) == ["rest"]
 
 
 def test_list_comp_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -176,7 +176,61 @@ def test_class_def_bindings():
             expr* decorator_list,
         )
     """
-    pass
+    node = _parse(
+        """
+        @decorator
+        class ClassName:
+            a = 1
+            def b(self):
+                pass
+        """
+    )
+    assert list(get_bindings(node)) == ["ClassName"]
+
+
+@walrus_operator
+def test_class_def_bindings_walrus_decorator():
+    node = _parse(
+        """
+        @(d := decorator())
+        class ClassName:
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["d", "ClassName"]
+
+
+@walrus_operator
+def test_class_def_bindings_walrus_base():
+    node = _parse(
+        """
+        class ClassName(BaseClass, (OtherBase := namedtuple())):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["OtherBase", "ClassName"]
+
+
+@walrus_operator
+def test_class_def_bindings_walrus_metaclass():
+    node = _parse(
+        """
+        class Class(metaclass=(class_meta := MetaClass)):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["class_meta", "Class"]
+
+
+@walrus_operator
+def test_class_def_bindings_walrus_body():
+    node = _parse(
+        """
+        class Class:
+            a = (prop := 2)
+        """
+    )
+    assert list(get_bindings(node)) == ["Class"]
 
 
 def test_return_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1305,7 +1305,14 @@ def test_attribute_bindings():
         # the following expression can appear in assignment context
         Attribute(expr value, identifier attr, expr_context ctx)
     """
-    pass
+    node = _parse("a.b.c")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_attribute_bindings_walrus():
+    node = _parse("(a_binding := a).b")
+    assert list(get_bindings(node)) == ["a_binding"]
 
 
 def test_subscript_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1265,22 +1265,27 @@ def test_call_bindings_walrus_args():
     ]
 
 
-def test_formatted_value_bindings():
-    """
-    ..code:: python
-
-        FormattedValue(expr value, int? conversion, expr? format_spec)
-    """
-    pass
-
-
 def test_joined_str_bindings():
     """
     ..code:: python
 
         JoinedStr(expr* values)
+        FormattedValue(expr value, int? conversion, expr? format_spec)
     """
-    pass
+    node = _parse('f"a: {a}"')
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_joined_str_bindings_walrus():
+    """
+    ..code:: python
+
+        JoinedStr(expr* values)
+        FormattedValue(expr value, int? conversion, expr? format_spec)
+    """
+    node = _parse('f"a: {(a := get_a())}"')
+    assert list(get_bindings(node)) == ["a"]
 
 
 def test_constant_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1294,7 +1294,8 @@ def test_constant_bindings():
 
         Constant(constant value, string? kind)
     """
-    pass
+    node = _parse("1")
+    assert list(get_bindings(node)) == []
 
 
 def test_attribute_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -430,7 +430,26 @@ def test_while_bindings():
 
         While(expr test, stmt* body, stmt* orelse)
     """
-    pass
+    node = _parse(
+        """
+        while test():
+            a = 1
+        else:
+            b = 2
+        """
+    )
+    assert list(get_bindings(node)) == ["a", "b"]
+
+
+@walrus_operator
+def test_while_bindings_walrus_test():
+    node = _parse(
+        """
+        while (value := test):
+            pass
+        """
+    )
+    assert list(get_bindings(node)) == ["value"]
 
 
 def test_if_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1365,12 +1365,17 @@ def test_starred_bindings():
 
         Starred(expr value, expr_context ctx)
     """
+    node = _parse("*a")
+    assert list(get_bindings(node)) == []
 
-    pass
+
+@walrus_operator
+def test_starred_bindings_walrus():
+    node = _parse("*(a_binding := a)")
+    assert list(get_bindings(node)) == ["a_binding"]
 
 
 def test_name_bindings():
-
     """
     ..code:: python
 
@@ -1381,7 +1386,6 @@ def test_name_bindings():
 
 
 def test_list_bindings():
-
     """
     ..code:: python
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1321,7 +1321,42 @@ def test_subscript_bindings():
 
         Subscript(expr value, expr slice, expr_context ctx)
     """
-    pass
+    node = _parse("a[b]")
+    assert list(get_bindings(node)) == []
+
+
+def test_subscript_bindings_slice():
+    node = _parse("a[b:c]")
+    assert list(get_bindings(node)) == []
+
+
+def test_subscript_bindings_slice_with_step():
+    node = _parse("a[b:c:d]")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_subscript_bindings_walrus_value():
+    node = _parse("(a_binding := a)[b]")
+    assert list(get_bindings(node)) == ["a_binding"]
+
+
+@walrus_operator
+def test_subscript_bindings_walrus_index():
+    node = _parse("a[(b_binding := b)]")
+    assert list(get_bindings(node)) == ["b_binding"]
+
+
+@walrus_operator
+def test_subscript_bindings_walrus_slice():
+    node = _parse("a[(b_binding := b):(c_binding := c)]")
+    assert list(get_bindings(node)) == ["b_binding", "c_binding"]
+
+
+@walrus_operator
+def test_subscript_bindings_walrus_slice_with_step():
+    node = _parse("a[(b_binding := b):(c_binding := c):(d_binding := d)]")
+    assert list(get_bindings(node)) == ["b_binding", "c_binding", "d_binding"]
 
 
 def test_starred_bindings():
@@ -1360,17 +1395,6 @@ def test_tuple_bindings():
     ..code:: python
 
         Tuple(expr* elts, expr_context ctx)
-
-    """
-    pass
-
-
-def test_slice_bindings():
-    """
-    ..code:: python
-
-        # can appear only in Subscript
-        Slice(expr? lower, expr? upper, expr? step)
 
     """
     pass

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1163,7 +1163,14 @@ def test_await_bindings():
         # the grammar constrains where yield expressions can occur
         Await(expr value)
     """
-    pass
+    node = _parse("await fun()")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_await_bindings_walrus():
+    node = _parse("await (r := fun())")
+    assert list(get_bindings(node)) == ["r"]
 
 
 def test_yield_bindings():
@@ -1172,7 +1179,19 @@ def test_yield_bindings():
 
         Yield(expr? value)
     """
-    pass
+    node = _parse("yield fun()")
+    assert list(get_bindings(node)) == []
+
+
+def test_yield_bindings_no_result():
+    node = _parse("yield")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_yield_bindings_walrus():
+    node = _parse("yield (r := fun())")
+    assert list(get_bindings(node)) == ["r"]
 
 
 def test_yield_from_bindings():
@@ -1181,7 +1200,14 @@ def test_yield_from_bindings():
 
         YieldFrom(expr value)
     """
-    pass
+    node = _parse("yield from fun()")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_yield_from_bindings_walrus():
+    node = _parse("yield from (r := fun())")
+    assert list(get_bindings(node)) == ["r"]
 
 
 def test_compare_bindings():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1391,7 +1391,25 @@ def test_list_bindings():
 
         List(expr* elts, expr_context ctx)
     """
-    pass
+    node = _parse("[a, b, c]")
+    assert list(get_bindings(node)) == []
+
+
+def test_list_bindings_unpack():
+    node = _parse("{a, b, *rest}")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_list_bindings_walrus():
+    node = _parse("[a, (b := genb()), c]")
+    assert list(get_bindings(node)) == ["b"]
+
+
+@walrus_operator
+def test_list_bindings_walrus_unpack():
+    node = _parse("[a, b, *(rest := other)]")
+    assert list(get_bindings(node)) == ["rest"]
 
 
 def test_tuple_bindings():
@@ -1399,6 +1417,23 @@ def test_tuple_bindings():
     ..code:: python
 
         Tuple(expr* elts, expr_context ctx)
-
     """
-    pass
+    node = _parse("(a, b, c)")
+    assert list(get_bindings(node)) == []
+
+
+def test_tuple_bindings_unpack():
+    node = _parse("(a, b, *rest)")
+    assert list(get_bindings(node)) == []
+
+
+@walrus_operator
+def test_tuple_bindings_walrus():
+    node = _parse("(a, (b := genb()), c)")
+    assert list(get_bindings(node)) == ["b"]
+
+
+@walrus_operator
+def test_tuple_bindings_walrus_unpack():
+    node = _parse("(a, b, *(rest := other))")
+    assert list(get_bindings(node)) == ["rest"]


### PR DESCRIPTION
Adds basic support for sorting code with bindings created using the walrus operator.

Requirements satisfied by bindings created within the same expression remain broken.  For example, the following is valid python, but will be rejected by ssort:
```python
(a := 1) + a
```
Hopefully nobody is going to do that though.