### PR TITLE
Bump minimum python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Software Development :: Libraries :: Python Modules
@@ -32,7 +31,7 @@ package_dir=
 packages = find:
 
 install_requires=
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Fixes #21

Commit 4b4e1a7d959fd5195be5ccf7c376a42c15d9c5f3 added python 3.8+ syntax to `topological_sort` so setup.cfg needs to reflect that minimum version requirement.

https://docs.python.org/3/whatsnew/3.8.html#positional-only-parameters