### PR TITLE
Centralize error reporting at the top of the stack

### DIFF
--- a/src/ssort/__init__.py
+++ b/src/ssort/__init__.py
@@ -1,11 +1,12 @@
 """
 The python source code statement sorter.
 """
-from ssort._exceptions import ResolutionError
+from ssort._exceptions import ResolutionError, WildcardImportError
 from ssort._ssort import ssort
 
-# Let linting tools know that we mean to re-export ResolutionError.
+# Let linting tools know that we do mean to re-export exception classes.
 assert ResolutionError is not None
+assert WildcardImportError is not None
 
 __version__ = "0.11.0"
 __all__ = ["ssort"]

--- a/src/ssort/_dependencies.py
+++ b/src/ssort/_dependencies.py
@@ -1,5 +1,4 @@
 from ssort._builtins import MODULE_BUILTINS
-from ssort._exceptions import ResolutionError, WildcardImportError
 from ssort._graphs import Graph
 from ssort._statements import (
     statement_bindings,
@@ -9,9 +8,7 @@ from ssort._statements import (
 )
 
 
-def module_statements_graph(
-    statements, *, on_unresolved=None, on_wildcard_import=None
-):
+def module_statements_graph(statements, *, on_unresolved, on_wildcard_import):
     """
     Constructs a graph of the interdependencies in a list of module level
     statements.
@@ -21,37 +18,19 @@ def module_statements_graph(
         the graph.
 
     :param on_unresolved:
-        An optional callback that should be invoked for each unresolved
-        dependency.  Can safely raise any arbitrary exception to abort
-        constructing the graph.  By default, will raise `ResolutionError` on
-        the first unresolved requirement.  If no exception is raised, the graph
-        returned by `module_statements_graph` will not contain a link for the
-        missing requirement.
+        An callback that should be invoked for each unresolved dependency.  Can
+        safely raise any arbitrary exception to abort constructing the graph.
+        If no exception is raised, the graph returned by this function will not
+        contain a link for the missing requirement.
     :param on_wildcard_import:
-        An optional callback that should be invoked if ssort detects a `*`
-        import.  By default, ssort will raise `WildcardImportError` and abort
-        construction of the graph.  If no exception is raised, all dangling
-        references will be pointed back to the last `*` import.
+        A callback that should be invoked if ssort detects a `*` import.  If no
+        exception is raised, all dangling references will be pointed back to the
+        last `*` import.
 
     :returns:
         A `Graph` mapping from statements to the set of statements that they
         depend on.
     """
-    if not on_unresolved:
-
-        def on_unresolved(name, *, lineno, col_offset, **kwargs):
-            raise ResolutionError(
-                f"could not resolve {name!r} at line {lineno}, column {col_offset}",
-                unresolved=name,
-            )
-
-    if not on_wildcard_import:
-
-        def on_wildcard_import(*, lineno, col_offset, **kwargs):
-            raise WildcardImportError(
-                "can't reliably determine dependencies on * import"
-            )
-
     # A dictionary mapping from names to the statements which bind them.
     scope = {}
 

--- a/src/ssort/_dependencies.py
+++ b/src/ssort/_dependencies.py
@@ -10,7 +10,7 @@ from ssort._statements import (
 )
 
 
-def statements_graph(statements):
+def module_statements_graph(statements):
     """
     Returns a dictionary mapping from statements to lists of other statements.
     """

--- a/src/ssort/_dependencies.py
+++ b/src/ssort/_dependencies.py
@@ -12,7 +12,16 @@ from ssort._statements import (
 
 def module_statements_graph(statements):
     """
-    Returns a dictionary mapping from statements to lists of other statements.
+    Constructs a graph of the interdependencies in a list of module level
+    statements.
+
+    :param statements:
+        An ordered list of opaque `Statement` objects from which to construct
+        the graph.
+
+    :returns:
+        A `Graph` mapping from statements to the set of statements that they
+        depend on.
     """
     # A dictionary mapping from names to the statements which bind them.
     scope = {}
@@ -89,6 +98,45 @@ def module_statements_graph(statements):
 
 
 def class_statements_initialisation_graph(statements):
+    """
+    Constructs a graph of the hard dependencies within a list of class level
+    statements.  These are dependencies that absolutely cannot be reordered
+    without changing the semantics of the script.
+
+    At inititialisation, class level statements can see earlier bindings in the
+    class body.
+
+    Note that this isn't a proper scope: variables from the containing scope are
+    not shadowed until after a binding is actually made and, obviously from the
+    need for a `self` argument, bindings are not captured.
+
+    The following example demonstrates some of this behaviour:
+
+    .. code:: python
+
+        >>> r = 1
+        >>> class A:
+        ...     a = r
+        ...     r = 2
+        ...     b = r
+        >>> r
+        1
+        >>> A.a
+        1
+        >>> A.b
+        2
+
+    If a name cannot be resolved at the class level we assume that it is
+    resolved at the module level and don't emit any warning.
+
+    :param statements:
+        An ordered list of opaque `Statement` objects from which to construct
+        the graph.
+
+    :returns:
+        A `Graph` mapping from statements to the set of statements that they
+        depend on.
+    """
     scope = {}
 
     graph = Graph()
@@ -113,13 +161,24 @@ def class_statements_initialisation_graph(statements):
 
 def class_statements_runtime_graph(statements, *, ignore_public):
     """
-    Returns a graph of dependencies between class methods and attributes of the
-    `self` argument.
+    Attempts to construct a graph of the soft, runtime dependencies between the
+    methods of a class.
 
-    If `ignore_public` is True, this will only contain references to private
-    attributes, leaving the sorting of public attributes to the programmer.
+    The graph is inferred by looking for attribute access on the `self` argument
+    of methods.
+
+    :param statements:
+        An ordered list of opaque `Statement` objects from which to construct
+        the graph.
+    :param ignore_public:
+        If true, the graph will only include references to private attributes,
+        i.e attributes prefixed by `_`.  This leaves the sorting of public
+        methods, which make up the interface of the class, to the programmer.
+
+    :returns:
+        A `Graph` mapping from statements to the set of statements that they
+        depend on.
     """
-
     scope = {}
 
     graph = Graph()

--- a/src/ssort/_exceptions.py
+++ b/src/ssort/_exceptions.py
@@ -1,4 +1,3 @@
 class ResolutionError(Exception):
     def __init__(self, msg, *, unresolved):
         super().__init__(msg)
-        self.unresolved = unresolved

--- a/src/ssort/_exceptions.py
+++ b/src/ssort/_exceptions.py
@@ -1,3 +1,7 @@
 class ResolutionError(Exception):
     def __init__(self, msg, *, unresolved):
         super().__init__(msg)
+
+
+class WildcardImportError(Exception):
+    pass

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -79,12 +79,18 @@ def main():
                 + f"line {lineno}, column {col_offset}\n"
             )
 
+        def _on_wildcard_import(**kwargs):
+            sys.stderr.write(
+                "WARNING: can't determine dependencies on * import\n"
+            )
+
         try:
             updated = ssort(
                 original,
                 filename=str(path),
                 on_syntax_error=_on_syntax_error,
                 on_unresolved=_on_unresolved,
+                on_wildcard_import=_on_wildcard_import,
             )
 
             if errors:

--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -4,7 +4,7 @@ import sys
 from ssort._dependencies import (
     class_statements_initialisation_graph,
     class_statements_runtime_graph,
-    statements_graph,
+    module_statements_graph,
 )
 from ssort._graphs import (
     is_topologically_sorted,
@@ -334,7 +334,7 @@ def statement_text_sorted(statement):
 def ssort(text, *, filename="<unknown>"):
     statements = list(split(text, filename=filename))
 
-    graph = statements_graph(statements)
+    graph = module_statements_graph(statements)
 
     replace_cycles(graph, key=sort_key_from_iter(statements))
 

--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -332,7 +332,12 @@ def statement_text_sorted(statement):
 
 
 def ssort(
-    text, *, filename="<unknown>", on_syntax_error=None, on_unresolved=None
+    text,
+    *,
+    filename="<unknown>",
+    on_syntax_error=None,
+    on_unresolved=None,
+    on_wildcard_import=None,
 ):
     if not on_syntax_error:
 
@@ -345,7 +350,11 @@ def ssort(
         on_syntax_error(exc.msg, lineno=exc.lineno, col_offset=exc.offset)
         return text
 
-    graph = module_statements_graph(statements, on_unresolved=on_unresolved)
+    graph = module_statements_graph(
+        statements,
+        on_unresolved=on_unresolved,
+        on_wildcard_import=on_wildcard_import,
+    )
     if graph is None:
         return text
 

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -8,6 +8,10 @@ def _clean(source):
     return textwrap.dedent(source).strip() + "\n"
 
 
+def _unreachable(*args, **kwargs):
+    raise AssertionError("unreachable")
+
+
 def test_dependencies_ordered_by_first_use():
     source = _clean(
         """
@@ -24,6 +28,8 @@ def test_dependencies_ordered_by_first_use():
         """
     )
     c, a, b = statements = list(split(source, filename="<unknown>"))
-    graph = module_statements_graph(statements)
+    graph = module_statements_graph(
+        statements, on_unresolved=_unreachable, on_wildcard_import=_unreachable
+    )
 
     assert list(graph.dependencies[a]) == [b, c]

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from ssort._dependencies import statements_graph
+from ssort._dependencies import module_statements_graph
 from ssort._parsing import split
 
 
@@ -24,6 +24,6 @@ def test_dependencies_ordered_by_first_use():
         """
     )
     c, a, b = statements = list(split(source, filename="<unknown>"))
-    graph = statements_graph(statements)
+    graph = module_statements_graph(statements)
 
     assert list(graph.dependencies[a]) == [b, c]

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -25,7 +25,11 @@ def test_examples(example):
     output_path = examples_dir / f"{example}_output.py"
     input_text = input_path.read_text()
 
-    actual_text = ssort(input_text, filename=str(input_path))
+    actual_text = ssort(
+        input_text,
+        filename=str(input_path),
+        on_wildcard_import=lambda **kwargs: None,
+    )
 
     # XXX Uncomment to update samples. XXX
     # output_path.write_text(actual_text)
@@ -42,7 +46,15 @@ def test_idempotent(example):
     input_path = examples_dir / f"{example}_input.py"
     input_text = input_path.read_text()
 
-    sorted_text = ssort(input_text, filename=str(input_path))
-    resorted_text = ssort(sorted_text, filename=str(input_path))
+    sorted_text = ssort(
+        input_text,
+        filename=str(input_path),
+        on_wildcard_import=lambda **kwargs: None,
+    )
+    resorted_text = ssort(
+        sorted_text,
+        filename=str(input_path),
+        on_wildcard_import=lambda **kwargs: None,
+    )
 
     assert resorted_text == sorted_text


### PR DESCRIPTION
This is prep work for skipping files based on `.gitignore` (#23).