### PR TITLE
Discover bindings made in format spec of format string

### DIFF
--- a/src/ssort/_bindings.py
+++ b/src/ssort/_bindings.py
@@ -677,6 +677,9 @@ def _get_bindings_for_formatted_value(node):
     """
     yield from get_bindings(node.value)
 
+    if node.format_spec is not None:
+        yield from get_bindings(node.format_spec)
+
 
 @get_bindings.register(ast.JoinedStr)
 def _get_bindings_for_joined_str(node):

--- a/src/ssort/_requirements.py
+++ b/src/ssort/_requirements.py
@@ -728,6 +728,9 @@ def _get_requirements_for_formatted_value(node):
     """
     yield from get_requirements(node.value)
 
+    if node.format_spec is not None:
+        yield from get_requirements(node.format_spec)
+
 
 @get_requirements.register(ast.JoinedStr)
 def _get_requirements_for_joined_str(node):
@@ -736,8 +739,8 @@ def _get_requirements_for_joined_str(node):
 
         JoinedStr(expr* values)
     """
-    return
-    yield
+    for value in node.values:
+        yield from get_requirements(value)
 
 
 @get_requirements.register(ast.Constant)

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1437,3 +1437,23 @@ def test_tuple_bindings_walrus():
 def test_tuple_bindings_walrus_unpack():
     node = _parse("(a, b, *(rest := other))")
     assert list(get_bindings(node)) == ["rest"]
+
+
+def test_formatted_value_bindings():
+    """
+    ..code:: python
+
+        FormattedValue(expr value, int conversion, expr? format_spec)
+    """
+    node = _parse("f'{a} {b} {c}'")
+    assert list(get_bindings(node)) == []
+
+
+def test_formatted_value_bindings_walrus():
+    node = _parse("f'{a} {1 + (b := 1)} {c}'")
+    assert list(get_bindings(node)) == ["b"]
+
+
+def test_formatted_value_bindings_format_spec_walrus():
+    node = _parse("f'{a} {b:{0 + (c := 0.3)}} {d}'")
+    assert list(get_bindings(node)) == ["c"]

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -836,7 +836,18 @@ def test_formatted_value_requirements():
 
         FormattedValue(expr value, int? conversion, expr? format_spec)
     """
-    pass
+    node = _parse("f'{a} {b} {c}'")
+    assert _dep_names(node) == ["a", "b", "c"]
+
+
+def test_formatted_value_requirements_format_spec():
+    node = _parse("f'{a} {b:{c}} {d}'")
+    assert _dep_names(node) == ["a", "b", "c", "d"]
+
+
+def test_formatted_value_requirements_format_spec_walrus():
+    node = _parse("f'{a} {b:{(c := 1)}} {d}'")
+    assert _dep_names(node) == ["a", "b", "d"]
 
 
 def test_joined_str_requirements():


### PR DESCRIPTION
Discover bindings made in the format spec of a format string.

Simple example illustrating how a variable can be bound inside a format spec:
```
>>> x
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'x' is not defined
>>>
>>> f"{3.1415:{(x := 0.3)}}"
'3.14'
>>>
>>> x
0.3
```