### PR TITLE
Move inner classes to top of body

### DIFF
--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -201,10 +201,14 @@ def _is_regular_operation(statement):
 
 def _is_property(statement):
     node = statement_node(statement)
-    if not isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign)):
-        return False
 
-    return True
+    return isinstance(node, (ast.Assign, ast.AnnAssign, ast.AugAssign))
+
+
+def _is_class(statement):
+    node = statement_node(statement)
+
+    return isinstance(node, ast.ClassDef)
 
 
 def _statement_binding_sort_key(binding_key):
@@ -246,6 +250,8 @@ def _statement_text_sorted_class(statement):
         statements, _is_regular_operation
     )
 
+    inner_classes, statements = _partition(statements, _is_class)
+
     properties, statements = _partition(statements, _is_property)
 
     methods, statements = statements, []
@@ -262,6 +268,9 @@ def _statement_text_sorted_class(statement):
             sort_key_from_iter(SPECIAL_PROPERTIES)
         ),
     )
+
+    # Inner classes (in original order).
+    sorted_statements += inner_classes
 
     # Regular properties (in original order).
     sorted_statements += properties

--- a/tests/test_ssort.py
+++ b/tests/test_ssort.py
@@ -427,3 +427,32 @@ def test_concat():
     )
     actual = ssort(original)
     assert actual == expected
+
+
+def test_inner_class():
+    original = _clean(
+        """
+        class Outer:
+            '''
+            The outer class.
+            '''
+            a = 4
+            class Inner:
+                pass
+            __slots__ = ("b",)
+        """
+    )
+    expected = _clean(
+        """
+        class Outer:
+            '''
+            The outer class.
+            '''
+            __slots__ = ("b",)
+            class Inner:
+                pass
+            a = 4
+        """
+    )
+    actual = ssort(original)
+    assert actual == expected


### PR DESCRIPTION
This is done to better support the common pattern of using an inner class to contain class metadata, as used in the django ORM and pydantic.  Previously, inner classes were treated in the same way as methods and mixed into the middle of the class.

Resolves #31.  Prompted by discussion in #11.