### PR TITLE
Pass message to on_unresolved hook

### DIFF
--- a/src/ssort/_dependencies.py
+++ b/src/ssort/_dependencies.py
@@ -85,7 +85,8 @@ def module_statements_graph(statements, *, on_unresolved, on_wildcard_import):
 
         for requirement in unresolved:
             on_unresolved(
-                requirement.name,
+                f"could not resolve {requirement.name!r}",
+                name=requirement.name,
                 lineno=requirement.lineno,
                 col_offset=requirement.col_offset,
             )

--- a/src/ssort/_exceptions.py
+++ b/src/ssort/_exceptions.py
@@ -9,9 +9,11 @@ class DecodingError(Exception):
 
 
 class ResolutionError(Exception):
-    def __init__(self, msg, *, unresolved):
+    def __init__(self, msg, *, name, lineno, col_offset):
         super().__init__(msg)
-        self.unresolved = unresolved
+        self.name = name
+        self.lineno = lineno
+        self.col_offset = col_offset
 
 
 class WildcardImportError(Exception):

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -93,7 +93,7 @@ def main():
                 + f"line {lineno}, column {col_offset}\n"
             )
 
-        def _on_unresolved(name, *, lineno, col_offset, **kwargs):
+        def _on_unresolved(message, *, name, lineno, col_offset, **kwargs):
             nonlocal errors
             errors = True
 

--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -391,14 +391,16 @@ def _interpret_on_syntax_error_action(on_syntax_error):
     return on_syntax_error
 
 
-def _on_unresolved_ignore(message, **kwargs):
+def _on_unresolved_ignore(message, *, name, lineno, col_offset, **kwargs):
     pass
 
 
-def _on_unresolved_raise(name, *, lineno, col_offset, **kwargs):
+def _on_unresolved_raise(message, *, name, lineno, col_offset, **kwargs):
     raise ResolutionError(
-        f"could not resolve {name!r} at line {lineno}, column {col_offset}",
-        unresolved=name,
+        message,
+        name=name,
+        lineno=lineno,
+        col_offset=col_offset,
     )
 
 

--- a/tests/test_error_hooks.py
+++ b/tests/test_error_hooks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ssort import DecodingError, UnknownEncodingError, ssort
+from ssort import DecodingError, ResolutionError, UnknownEncodingError, ssort
 
 
 class _DummyException(Exception):
@@ -67,4 +67,44 @@ def test_on_decoding_error_callback():
         ssort(original, on_decoding_error=on_decoding_error)
     assert exc_info.value.args == (
         "'ascii' codec can't decode byte 0xfe in position 15: ordinal not in range(128)",
+    )
+
+
+# === Unresolved ===============================================================
+
+
+def test_on_unresolved_raise():
+    original = "def fun():\n    unresolved()"
+
+    with pytest.raises(ResolutionError) as exc_info:
+        ssort(original, on_unresolved="raise")
+
+    assert str(exc_info.value) == "could not resolve 'unresolved'"
+    assert exc_info.value.name == "unresolved"
+    assert exc_info.value.lineno == 2
+    assert exc_info.value.col_offset == 4
+
+
+def test_on_unresolved_ignore():
+    original = "def fun():\n    unresolved()"
+
+    actual = ssort(original, on_unresolved="ignore")
+
+    assert actual == original
+
+
+def test_on_unresolved_callback():
+    original = "def fun():\n    unresolved()"
+
+    def on_unresolved(message, *, name, lineno, col_offset):
+        raise _DummyException(message, name, lineno, col_offset)
+
+    with pytest.raises(_DummyException) as exc_info:
+        ssort(original, on_unresolved=on_unresolved)
+
+    assert exc_info.value.args == (
+        "could not resolve 'unresolved'",
+        "unresolved",
+        2,
+        4,
     )


### PR DESCRIPTION
This just makes the `on_unresolved` callback a little bit more consistent with the other hooks.