### PR TITLE
Fix awkward reuse of `split` function by creating `parse` wrapper

### DIFF
--- a/src/ssort/_parsing.py
+++ b/src/ssort/_parsing.py
@@ -30,11 +30,10 @@ def _find_end(node):
 def split(
     root_text,
     *,
-    nodes=None,
+    nodes,
     next_row=0,
     next_col=0,
     indent=0,
-    filename="<unknown>"
 ):
     # Build an index of row lengths and start offsets to enable fast string
     # indexing using ast row/column coordinates.
@@ -46,13 +45,7 @@ def split(
             row_offsets.append(offset + 1)
     row_lengths.append(len(root_text) - row_offsets[-1])
 
-    if nodes is None:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            root_node = ast.parse(root_text, filename)
-        nodes = iter(root_node.body)
-    else:
-        nodes = iter(nodes)
+    nodes = iter(nodes)
 
     next_node = next(nodes, None)
 
@@ -205,3 +198,10 @@ def split_class(statement):
         )
 
     return head_text, body_statements
+
+
+def parse(root_text, *, filename="<unknown>"):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        root_node = ast.parse(root_text, filename)
+    return split(root_text, nodes=list(root_node.body))

--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -17,7 +17,7 @@ from ssort._graphs import (
     replace_cycles,
     topological_sort,
 )
-from ssort._parsing import split, split_class
+from ssort._parsing import parse, split_class
 from ssort._statements import (
     statement_bindings,
     statement_node,
@@ -468,7 +468,7 @@ def ssort(
         return text
 
     try:
-        statements = list(split(text, filename=filename))
+        statements = list(parse(text, filename=filename))
     except SyntaxError as exc:
         on_syntax_error(exc.msg, lineno=exc.lineno, col_offset=exc.offset)
         return text

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from ssort._dependencies import module_statements_graph
-from ssort._parsing import split
+from ssort._parsing import parse
 
 
 def _clean(source):
@@ -27,7 +27,7 @@ def test_dependencies_ordered_by_first_use():
             pass
         """
     )
-    c, a, b = statements = list(split(source, filename="<unknown>"))
+    c, a, b = statements = list(parse(source, filename="<unknown>"))
     graph = module_statements_graph(
         statements, on_unresolved=_unreachable, on_wildcard_import=_unreachable
     )

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,11 +1,11 @@
-from ssort._parsing import split, split_class
+from ssort._parsing import parse, split_class
 from ssort._statements import statement_text
 
 
 def _split_text(source):
     return [
         statement_text(statement)
-        for statement in split(source, filename="<unknown>")
+        for statement in parse(source, filename="<unknown>")
     ]
 
 
@@ -78,7 +78,7 @@ def test_split_function_def():
 
 
 def _split_class(source, index=-1):
-    statements = list(split(source))
+    statements = list(parse(source))
     head, body = split_class(statements[index])
     return head, [statement_text(child) for child in body]
 

--- a/tests/test_statements.py
+++ b/tests/test_statements.py
@@ -1,12 +1,12 @@
-from ssort._parsing import split
+from ssort._parsing import parse
 from ssort._statements import statement_text_padded
 
 
 def test_statement_text_padded_same_row():
-    statements = list(split("a = 4; b = 5"))
+    statements = list(parse("a = 4; b = 5"))
     assert statement_text_padded(statements[1]) == "       b = 5"
 
 
 def test_statement_text_padded_separate_rows():
-    statements = list(split("a = 4\n\nb = 5"))
+    statements = list(parse("a = 4\n\nb = 5"))
     assert statement_text_padded(statements[1]) == "\n\nb = 5"


### PR DESCRIPTION
This is mostly setting the scene for renaming the `on_syntax_error` hook to `on_parse_error` to avoid name clash with stdlib `SyntaxError`.  It should also help a little bit with adding type annotations.