### PR TITLE
Replace SyntaxError with custom ParseError and fix corresponding hooks

### DIFF
--- a/src/ssort/__init__.py
+++ b/src/ssort/__init__.py
@@ -3,6 +3,7 @@ The python source code statement sorter.
 """
 from ssort._exceptions import (
     DecodingError,
+    ParseError,
     ResolutionError,
     UnknownEncodingError,
     WildcardImportError,
@@ -11,6 +12,7 @@ from ssort._ssort import ssort
 
 # Let linting tools know that we do mean to re-export exception classes.
 assert DecodingError is not None
+assert ParseError is not None
 assert ResolutionError is not None
 assert UnknownEncodingError is not None
 assert WildcardImportError is not None

--- a/src/ssort/_exceptions.py
+++ b/src/ssort/_exceptions.py
@@ -8,6 +8,13 @@ class DecodingError(Exception):
     pass
 
 
+class ParseError(Exception):
+    def __init__(self, msg, *, lineno, col_offset):
+        super().__init__(msg)
+        self.lineno = lineno
+        self.col_offset = col_offset
+
+
 class ResolutionError(Exception):
     def __init__(self, msg, *, name, lineno, col_offset):
         super().__init__(msg)

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -84,7 +84,7 @@ def main():
             unsortable += 1
             continue
 
-        def _on_syntax_error(message, *, lineno, col_offset, **kwargs):
+        def _on_parse_error(message, *, lineno, col_offset, **kwargs):
             nonlocal errors
             errors = True
 
@@ -112,7 +112,7 @@ def main():
             updated = ssort(
                 original,
                 filename=str(path),
-                on_syntax_error=_on_syntax_error,
+                on_parse_error=_on_parse_error,
                 on_unresolved=_on_unresolved,
                 on_wildcard_import=_on_wildcard_import,
             )

--- a/src/ssort/_parsing.py
+++ b/src/ssort/_parsing.py
@@ -4,6 +4,7 @@ from io import StringIO
 from token import NAME
 from tokenize import generate_tokens
 
+from ssort._exceptions import ParseError
 from ssort._statements import (
     Statement,
     statement_node,
@@ -203,5 +204,8 @@ def split_class(statement):
 def parse(root_text, *, filename="<unknown>"):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        root_node = ast.parse(root_text, filename)
+        try:
+            root_node = ast.parse(root_text, filename)
+        except SyntaxError as exc:
+            raise ParseError(exc.msg, lineno=exc.lineno, col_offset=exc.offset)
     return split(root_text, nodes=list(root_node.body))

--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -8,6 +8,7 @@ from ssort._dependencies import (
 )
 from ssort._exceptions import (
     DecodingError,
+    ParseError,
     ResolutionError,
     UnknownEncodingError,
     WildcardImportError,
@@ -373,22 +374,22 @@ def _interpret_on_decoding_error_action(on_decoding_error):
     return on_decoding_error
 
 
-def _on_syntax_error_ignore(message, **kwargs):
+def _on_parse_error_ignore(message, **kwargs):
     pass
 
 
-def _on_syntax_error_raise(message, *, lineno, col_offset, **kwargs):
-    raise SyntaxError(message, lineno=lineno, offset=col_offset)
+def _on_parse_error_raise(message, *, lineno, col_offset, **kwargs):
+    raise ParseError(message, lineno=lineno, col_offset=col_offset)
 
 
-def _interpret_on_syntax_error_action(on_syntax_error):
-    if on_syntax_error == "ignore":
-        return _on_syntax_error_ignore
+def _interpret_on_parse_error_action(on_parse_error):
+    if on_parse_error == "ignore":
+        return _on_parse_error_ignore
 
-    if on_syntax_error == "raise":
-        return _on_syntax_error_raise
+    if on_parse_error == "raise":
+        return _on_parse_error_raise
 
-    return on_syntax_error
+    return on_parse_error
 
 
 def _on_unresolved_ignore(message, *, name, lineno, col_offset, **kwargs):
@@ -440,7 +441,7 @@ def ssort(
     filename="<unknown>",
     on_unknown_encoding_error="raise",
     on_decoding_error="raise",
-    on_syntax_error="raise",
+    on_parse_error="raise",
     on_unresolved="raise",
     on_wildcard_import="raise",
 ):
@@ -448,7 +449,7 @@ def ssort(
         on_unknown_encoding_error
     )
     on_decoding_error = _interpret_on_decoding_error_action(on_decoding_error)
-    on_syntax_error = _interpret_on_syntax_error_action(on_syntax_error)
+    on_parse_error = _interpret_on_parse_error_action(on_parse_error)
     on_unresolved = _interpret_on_unresolved_action(on_unresolved)
     on_wildcard_import = _interpret_on_wildcard_import_action(
         on_wildcard_import
@@ -469,8 +470,8 @@ def ssort(
 
     try:
         statements = list(parse(text, filename=filename))
-    except SyntaxError as exc:
-        on_syntax_error(exc.msg, lineno=exc.lineno, col_offset=exc.offset)
+    except ParseError as exc:
+        on_parse_error(str(exc), lineno=exc.lineno, col_offset=exc.col_offset)
         return text
 
     graph = module_statements_graph(


### PR DESCRIPTION
This gives better control over error reporting, and is more consistent with how other errors are handled.  It makes it practical to fix some stupid bugs in the hook where attributes are being set the wrong way.