### PR TITLE
Exclude files in .gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ line_length = 79
 profile = "black"
 multi_line_output = 3
 line_length = 79
+
+[[tool.mypy.overrides]]
+module = "pathspec"
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ package_dir=
     =src
 packages = find:
 
-install_requires=
+install_requires =
+    pathspec >=0.9.0
 python_requires = >=3.8
 
 [options.packages.find]

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -280,24 +280,3 @@ def gen_python_files(
             include_match = include.search(normalized_path) if include else True
             if include_match:
                 yield child
-
-
-def wrap_stream_for_windows(
-    f: io.TextIOWrapper,
-) -> Union[io.TextIOWrapper, "colorama.AnsiToWin32"]:
-    """
-    Wrap stream with colorama's wrap_stream so colors are shown on Windows.
-
-    If `colorama` is unavailable, the original stream is returned unmodified.
-    Otherwise, the `wrap_stream()` function determines whether the stream needs
-    to be wrapped for a Windows environment and will accordingly either return
-    an `AnsiToWin32` wrapper or the original stream.
-    """
-    try:
-        from colorama.initialise import wrap_stream
-    except ImportError:
-        return f
-    else:
-        # Set `strip=False` to avoid needing to modify test_express_diff_with_color.
-        return wrap_stream(f, convert=None, strip=False, autoreset=False, wrap=True)
-

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -55,17 +55,18 @@ def find_python_files(
         patterns = ["."]
 
     paths_set = set()
-    paths_list = []
     for pattern in patterns:
         path = pathlib.Path(pattern)
         if path.suffix == ".py":
             subpaths = [path]
         else:
-            subpaths = list(path.glob("**/*.py"))
+            subpaths = [
+                subpath
+                for subpath in path.glob("**/*.py")
+                if not is_ignored(subpath)
+            ]
 
         for subpath in sorted(subpaths):
             if subpath not in paths_set:
                 paths_set.add(subpath)
-                paths_list.append(subpath)
-
-    return [path for path in paths_list if not is_ignored(path)]
+                yield subpath

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -1,282 +1,73 @@
-# Originally taken from the `black` project:
-#   https://github.com/psf/black/blob/07a2e6f67810a8949b76a26c434c91d3fda7ac24/src/black/files.py
-#
-# Original license, as of first commit:
-#
-#   The MIT License (MIT)
-#
-#   Copyright (c) 2018 Łukasz Langa
-#
-#   Permission is hereby granted, free of charge, to any person obtaining a copy
-#   of this software and associated documentation files (the "Software"), to deal
-#   in the Software without restriction, including without limitation the rights
-#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-#   copies of the Software, and to permit persons to whom the Software is
-#   furnished to do so, subject to the following conditions:
-#
-#   The above copyright notice and this permission notice shall be included in all
-#   copies or substantial portions of the Software.
-#
-#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-#   SOFTWARE.
+from __future__ import annotations
 
-from functools import lru_cache
-import io
 import os
-from pathlib import Path
-import sys
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Pattern,
-    Sequence,
-    Tuple,
-    Union,
-    TYPE_CHECKING,
-)
+import pathlib
+from typing import Iterable
 
-from mypy_extensions import mypyc_attr
-from pathspec import PathSpec
-from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
-import tomli
+import pathspec
 
-from black.output import err
-from black.report import Report
-from black.handle_ipynb_magics import jupyter_dependencies_are_installed
+from ssort._utils import memoize
 
-if TYPE_CHECKING:
-    import colorama  # noqa: F401
+_EMPTY_PATH_SPEC = pathspec.PathSpec([])
 
 
-@lru_cache()
-def find_project_root(srcs: Sequence[str]) -> Tuple[Path, str]:
-    """Return a directory containing .git, .hg, or pyproject.toml.
+def _is_project_root(path: pathlib.Path) -> bool:
+    if path == path.root or path == path.parent:
+        return True
 
-    That directory will be a common parent of all files and directories
-    passed in `srcs`.
+    if (path / ".git").is_dir():
+        return True
 
-    If no directory in the tree contains a marker that would specify it's the
-    project root, the root of the file system is returned.
-
-    Returns a two-tuple with the first element as the project root path and
-    the second element as a string describing the method by which the
-    project root was discovered.
-    """
-    if not srcs:
-        srcs = [str(Path.cwd().resolve())]
-
-    path_srcs = [Path(Path.cwd(), src).resolve() for src in srcs]
-
-    # A list of lists of parents for each 'src'. 'src' is included as a
-    # "parent" of itself if it is a directory
-    src_parents = [
-        list(path.parents) + ([path] if path.is_dir() else []) for path in path_srcs
-    ]
-
-    common_base = max(
-        set.intersection(*(set(parents) for parents in src_parents)),
-        key=lambda path: path.parts,
-    )
-
-    for directory in (common_base, *common_base.parents):
-        if (directory / ".git").exists():
-            return directory, ".git directory"
-
-        if (directory / ".hg").is_dir():
-            return directory, ".hg directory"
-
-        if (directory / "pyproject.toml").is_file():
-            return directory, "pyproject.toml"
-
-    return directory, "file system root"
+    return False
 
 
-def find_pyproject_toml(path_search_start: Tuple[str, ...]) -> Optional[str]:
-    """Find the absolute filepath to a pyproject.toml if it exists"""
-    path_project_root, _ = find_project_root(path_search_start)
-    path_pyproject_toml = path_project_root / "pyproject.toml"
-    if path_pyproject_toml.is_file():
-        return str(path_pyproject_toml)
+def _get_ignore_patterns(path: pathlib.Path) -> pathspec.PathSpec:
+    git_ignore = path / ".gitignore"
+    if git_ignore.is_file():
+        with git_ignore.open() as f:
+            return pathspec.PathSpec.from_lines("gitwildmatch", f)
 
+    return _EMPTY_PATH_SPEC
+
+
+@memoize
+def _resolve_ignore_patterns(
+    path: pathlib.Path,
+) -> pathspec.PathSpec:
+    if _is_project_root(path):
+        return _get_ignore_patterns(path)
+
+    return _resolve_ignore_patterns(path.parent) + _get_ignore_patterns(path)
+
+
+def is_ignored(path: pathlib.Path) -> bool:
     try:
-        path_user_pyproject_toml = find_user_pyproject_toml()
-        return (
-            str(path_user_pyproject_toml)
-            if path_user_pyproject_toml.is_file()
-            else None
-        )
-    except (PermissionError, RuntimeError) as e:
-        # We do not have access to the user-level config directory, so ignore it.
-        err(f"Ignoring user configuration directory due to {e!r}")
-        return None
+        path = path.resolve()
+    except RuntimeError:
+        return True
+
+    ignore_patterns = _resolve_ignore_patterns(path)
+    return ignore_patterns.match_file(path)
 
 
-@mypyc_attr(patchable=True)
-def parse_pyproject_toml(path_config: str) -> Dict[str, Any]:
-    """Parse a pyproject toml file, pulling out relevant parts for Black
+def find_python_files(
+    patterns: Iterable[str | os.PathLike[str]],
+) -> Iterable[pathlib.Path]:
+    if not patterns:
+        patterns = ["."]
 
-    If parsing fails, will raise a tomli.TOMLDecodeError
-    """
-    with open(path_config, "rb") as f:
-        pyproject_toml = tomli.load(f)
-    config = pyproject_toml.get("tool", {}).get("black", {})
-    return {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
+    paths_set = set()
+    paths_list = []
+    for pattern in patterns:
+        path = pathlib.Path(pattern)
+        if path.suffix == ".py":
+            subpaths = [path]
+        else:
+            subpaths = list(path.glob("**/*.py"))
 
+        for subpath in sorted(subpaths):
+            if subpath not in paths_set:
+                paths_set.add(subpath)
+                paths_list.append(subpath)
 
-@lru_cache()
-def find_user_pyproject_toml() -> Path:
-    r"""Return the path to the top-level user configuration for black.
-
-    This looks for ~\.black on Windows and ~/.config/black on Linux and other
-    Unix systems.
-
-    May raise:
-    - RuntimeError: if the current user has no homedir
-    - PermissionError: if the current process cannot access the user's homedir
-    """
-    if sys.platform == "win32":
-        # Windows
-        user_config_path = Path.home() / ".black"
-    else:
-        config_root = os.environ.get("XDG_CONFIG_HOME", "~/.config")
-        user_config_path = Path(config_root).expanduser() / "black"
-    return user_config_path.resolve()
-
-
-@lru_cache()
-def get_gitignore(root: Path) -> PathSpec:
-    """Return a PathSpec matching gitignore content if present."""
-    gitignore = root / ".gitignore"
-    lines: List[str] = []
-    if gitignore.is_file():
-        with gitignore.open(encoding="utf-8") as gf:
-            lines = gf.readlines()
-    try:
-        return PathSpec.from_lines("gitwildmatch", lines)
-    except GitWildMatchPatternError as e:
-        err(f"Could not parse {gitignore}: {e}")
-        raise
-
-
-def normalize_path_maybe_ignore(
-    path: Path,
-    root: Path,
-    report: Optional[Report] = None,
-) -> Optional[str]:
-    """Normalize `path`. May return `None` if `path` was ignored.
-
-    `report` is where "path ignored" output goes.
-    """
-    try:
-        abspath = path if path.is_absolute() else Path.cwd() / path
-        normalized_path = abspath.resolve().relative_to(root).as_posix()
-    except OSError as e:
-        if report:
-            report.path_ignored(path, f"cannot be read because {e}")
-        return None
-
-    except ValueError:
-        if path.is_symlink():
-            if report:
-                report.path_ignored(
-                    path, f"is a symbolic link that points outside {root}"
-                )
-            return None
-
-        raise
-
-    return normalized_path
-
-
-def path_is_excluded(
-    normalized_path: str,
-    pattern: Optional[Pattern[str]],
-) -> bool:
-    match = pattern.search(normalized_path) if pattern else None
-    return bool(match and match.group(0))
-
-
-def gen_python_files(
-    paths: Iterable[Path],
-    root: Path,
-    include: Pattern[str],
-    exclude: Pattern[str],
-    extend_exclude: Optional[Pattern[str]],
-    force_exclude: Optional[Pattern[str]],
-    report: Report,
-    gitignore: Optional[PathSpec],
-    *,
-    verbose: bool,
-    quiet: bool,
-) -> Iterator[Path]:
-    """Generate all files under `path` whose paths are not excluded by the
-    `exclude_regex`, `extend_exclude`, or `force_exclude` regexes,
-    but are included by the `include` regex.
-
-    Symbolic links pointing outside of the `root` directory are ignored.
-
-    `report` is where output about exclusions goes.
-    """
-    assert root.is_absolute(), f"INTERNAL ERROR: `root` must be absolute but is {root}"
-    for child in paths:
-        normalized_path = normalize_path_maybe_ignore(child, root, report)
-        if normalized_path is None:
-            continue
-
-        # First ignore files matching .gitignore, if passed
-        if gitignore is not None and gitignore.match_file(normalized_path):
-            report.path_ignored(child, "matches the .gitignore file content")
-            continue
-
-        # Then ignore with `--exclude` `--extend-exclude` and `--force-exclude` options.
-        normalized_path = "/" + normalized_path
-        if child.is_dir():
-            normalized_path += "/"
-
-        if path_is_excluded(normalized_path, exclude):
-            report.path_ignored(child, "matches the --exclude regular expression")
-            continue
-
-        if path_is_excluded(normalized_path, extend_exclude):
-            report.path_ignored(
-                child, "matches the --extend-exclude regular expression"
-            )
-            continue
-
-        if path_is_excluded(normalized_path, force_exclude):
-            report.path_ignored(child, "matches the --force-exclude regular expression")
-            continue
-
-        if child.is_dir():
-            # If gitignore is None, gitignore usage is disabled, while a Falsey
-            # gitignore is when the directory doesn't have a .gitignore file.
-            yield from gen_python_files(
-                child.iterdir(),
-                root,
-                include,
-                exclude,
-                extend_exclude,
-                force_exclude,
-                report,
-                gitignore + get_gitignore(child) if gitignore is not None else None,
-                verbose=verbose,
-                quiet=quiet,
-            )
-
-        elif child.is_file():
-            if child.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
-                verbose=verbose, quiet=quiet
-            ):
-                continue
-            include_match = include.search(normalized_path) if include else True
-            if include_match:
-                yield child
+    return [path for path in paths_list if not is_ignored(path)]

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -1,0 +1,303 @@
+# Originally taken from the `black` project:
+#   https://github.com/psf/black/blob/07a2e6f67810a8949b76a26c434c91d3fda7ac24/src/black/files.py
+#
+# Original license, as of first commit:
+#
+#   The MIT License (MIT)
+#
+#   Copyright (c) 2018 Łukasz Langa
+#
+#   Permission is hereby granted, free of charge, to any person obtaining a copy
+#   of this software and associated documentation files (the "Software"), to deal
+#   in the Software without restriction, including without limitation the rights
+#   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#   copies of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in all
+#   copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+#   SOFTWARE.
+
+from functools import lru_cache
+import io
+import os
+from pathlib import Path
+import sys
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Pattern,
+    Sequence,
+    Tuple,
+    Union,
+    TYPE_CHECKING,
+)
+
+from mypy_extensions import mypyc_attr
+from pathspec import PathSpec
+from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
+import tomli
+
+from black.output import err
+from black.report import Report
+from black.handle_ipynb_magics import jupyter_dependencies_are_installed
+
+if TYPE_CHECKING:
+    import colorama  # noqa: F401
+
+
+@lru_cache()
+def find_project_root(srcs: Sequence[str]) -> Tuple[Path, str]:
+    """Return a directory containing .git, .hg, or pyproject.toml.
+
+    That directory will be a common parent of all files and directories
+    passed in `srcs`.
+
+    If no directory in the tree contains a marker that would specify it's the
+    project root, the root of the file system is returned.
+
+    Returns a two-tuple with the first element as the project root path and
+    the second element as a string describing the method by which the
+    project root was discovered.
+    """
+    if not srcs:
+        srcs = [str(Path.cwd().resolve())]
+
+    path_srcs = [Path(Path.cwd(), src).resolve() for src in srcs]
+
+    # A list of lists of parents for each 'src'. 'src' is included as a
+    # "parent" of itself if it is a directory
+    src_parents = [
+        list(path.parents) + ([path] if path.is_dir() else []) for path in path_srcs
+    ]
+
+    common_base = max(
+        set.intersection(*(set(parents) for parents in src_parents)),
+        key=lambda path: path.parts,
+    )
+
+    for directory in (common_base, *common_base.parents):
+        if (directory / ".git").exists():
+            return directory, ".git directory"
+
+        if (directory / ".hg").is_dir():
+            return directory, ".hg directory"
+
+        if (directory / "pyproject.toml").is_file():
+            return directory, "pyproject.toml"
+
+    return directory, "file system root"
+
+
+def find_pyproject_toml(path_search_start: Tuple[str, ...]) -> Optional[str]:
+    """Find the absolute filepath to a pyproject.toml if it exists"""
+    path_project_root, _ = find_project_root(path_search_start)
+    path_pyproject_toml = path_project_root / "pyproject.toml"
+    if path_pyproject_toml.is_file():
+        return str(path_pyproject_toml)
+
+    try:
+        path_user_pyproject_toml = find_user_pyproject_toml()
+        return (
+            str(path_user_pyproject_toml)
+            if path_user_pyproject_toml.is_file()
+            else None
+        )
+    except (PermissionError, RuntimeError) as e:
+        # We do not have access to the user-level config directory, so ignore it.
+        err(f"Ignoring user configuration directory due to {e!r}")
+        return None
+
+
+@mypyc_attr(patchable=True)
+def parse_pyproject_toml(path_config: str) -> Dict[str, Any]:
+    """Parse a pyproject toml file, pulling out relevant parts for Black
+
+    If parsing fails, will raise a tomli.TOMLDecodeError
+    """
+    with open(path_config, "rb") as f:
+        pyproject_toml = tomli.load(f)
+    config = pyproject_toml.get("tool", {}).get("black", {})
+    return {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
+
+
+@lru_cache()
+def find_user_pyproject_toml() -> Path:
+    r"""Return the path to the top-level user configuration for black.
+
+    This looks for ~\.black on Windows and ~/.config/black on Linux and other
+    Unix systems.
+
+    May raise:
+    - RuntimeError: if the current user has no homedir
+    - PermissionError: if the current process cannot access the user's homedir
+    """
+    if sys.platform == "win32":
+        # Windows
+        user_config_path = Path.home() / ".black"
+    else:
+        config_root = os.environ.get("XDG_CONFIG_HOME", "~/.config")
+        user_config_path = Path(config_root).expanduser() / "black"
+    return user_config_path.resolve()
+
+
+@lru_cache()
+def get_gitignore(root: Path) -> PathSpec:
+    """Return a PathSpec matching gitignore content if present."""
+    gitignore = root / ".gitignore"
+    lines: List[str] = []
+    if gitignore.is_file():
+        with gitignore.open(encoding="utf-8") as gf:
+            lines = gf.readlines()
+    try:
+        return PathSpec.from_lines("gitwildmatch", lines)
+    except GitWildMatchPatternError as e:
+        err(f"Could not parse {gitignore}: {e}")
+        raise
+
+
+def normalize_path_maybe_ignore(
+    path: Path,
+    root: Path,
+    report: Optional[Report] = None,
+) -> Optional[str]:
+    """Normalize `path`. May return `None` if `path` was ignored.
+
+    `report` is where "path ignored" output goes.
+    """
+    try:
+        abspath = path if path.is_absolute() else Path.cwd() / path
+        normalized_path = abspath.resolve().relative_to(root).as_posix()
+    except OSError as e:
+        if report:
+            report.path_ignored(path, f"cannot be read because {e}")
+        return None
+
+    except ValueError:
+        if path.is_symlink():
+            if report:
+                report.path_ignored(
+                    path, f"is a symbolic link that points outside {root}"
+                )
+            return None
+
+        raise
+
+    return normalized_path
+
+
+def path_is_excluded(
+    normalized_path: str,
+    pattern: Optional[Pattern[str]],
+) -> bool:
+    match = pattern.search(normalized_path) if pattern else None
+    return bool(match and match.group(0))
+
+
+def gen_python_files(
+    paths: Iterable[Path],
+    root: Path,
+    include: Pattern[str],
+    exclude: Pattern[str],
+    extend_exclude: Optional[Pattern[str]],
+    force_exclude: Optional[Pattern[str]],
+    report: Report,
+    gitignore: Optional[PathSpec],
+    *,
+    verbose: bool,
+    quiet: bool,
+) -> Iterator[Path]:
+    """Generate all files under `path` whose paths are not excluded by the
+    `exclude_regex`, `extend_exclude`, or `force_exclude` regexes,
+    but are included by the `include` regex.
+
+    Symbolic links pointing outside of the `root` directory are ignored.
+
+    `report` is where output about exclusions goes.
+    """
+    assert root.is_absolute(), f"INTERNAL ERROR: `root` must be absolute but is {root}"
+    for child in paths:
+        normalized_path = normalize_path_maybe_ignore(child, root, report)
+        if normalized_path is None:
+            continue
+
+        # First ignore files matching .gitignore, if passed
+        if gitignore is not None and gitignore.match_file(normalized_path):
+            report.path_ignored(child, "matches the .gitignore file content")
+            continue
+
+        # Then ignore with `--exclude` `--extend-exclude` and `--force-exclude` options.
+        normalized_path = "/" + normalized_path
+        if child.is_dir():
+            normalized_path += "/"
+
+        if path_is_excluded(normalized_path, exclude):
+            report.path_ignored(child, "matches the --exclude regular expression")
+            continue
+
+        if path_is_excluded(normalized_path, extend_exclude):
+            report.path_ignored(
+                child, "matches the --extend-exclude regular expression"
+            )
+            continue
+
+        if path_is_excluded(normalized_path, force_exclude):
+            report.path_ignored(child, "matches the --force-exclude regular expression")
+            continue
+
+        if child.is_dir():
+            # If gitignore is None, gitignore usage is disabled, while a Falsey
+            # gitignore is when the directory doesn't have a .gitignore file.
+            yield from gen_python_files(
+                child.iterdir(),
+                root,
+                include,
+                exclude,
+                extend_exclude,
+                force_exclude,
+                report,
+                gitignore + get_gitignore(child) if gitignore is not None else None,
+                verbose=verbose,
+                quiet=quiet,
+            )
+
+        elif child.is_file():
+            if child.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
+                verbose=verbose, quiet=quiet
+            ):
+                continue
+            include_match = include.search(normalized_path) if include else True
+            if include_match:
+                yield child
+
+
+def wrap_stream_for_windows(
+    f: io.TextIOWrapper,
+) -> Union[io.TextIOWrapper, "colorama.AnsiToWin32"]:
+    """
+    Wrap stream with colorama's wrap_stream so colors are shown on Windows.
+
+    If `colorama` is unavailable, the original stream is returned unmodified.
+    Otherwise, the `wrap_stream()` function determines whether the stream needs
+    to be wrapped for a Windows environment and will accordingly either return
+    an `AnsiToWin32` wrapper or the original stream.
+    """
+    try:
+        from colorama.initialise import wrap_stream
+    except ImportError:
+        return f
+    else:
+        # Set `strip=False` to avoid needing to modify test_express_diff_with_color.
+        return wrap_stream(f, convert=None, strip=False, autoreset=False, wrap=True)
+

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -32,7 +32,7 @@ def _get_ignore_patterns(path: pathlib.Path) -> pathspec.PathSpec:
     return _EMPTY_PATH_SPEC
 
 
-def is_ignored(path: pathlib.Path) -> bool:
+def is_ignored(path: str | os.PathLike) -> bool:
     # Can't use pathlib.Path.resolve() here because we want to maintain
     # symbolic links.
     path = pathlib.Path(os.path.abspath(path))

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -45,6 +45,8 @@ def is_ignored(path: pathlib.Path) -> bool:
         if _is_project_root(part):
             return False
 
+    return False
+
 
 def find_python_files(
     patterns: Iterable[str | os.PathLike[str]],

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -1,32 +1,11 @@
 import argparse
 import difflib
-import pathlib
 import sys
 
 from ssort._exceptions import UnknownEncodingError
+from ssort._files import find_python_files
 from ssort._ssort import ssort
 from ssort._utils import detect_encoding
-
-
-def _find_files(patterns):
-    if not patterns:
-        patterns = ["."]
-
-    paths_set = set()
-    paths_list = []
-    for pattern in patterns:
-        path = pathlib.Path(pattern)
-        if path.suffix == ".py":
-            subpaths = [path]
-        else:
-            subpaths = list(path.glob("**/*.py"))
-
-        for subpath in sorted(subpaths):
-            if subpath not in paths_set:
-                paths_set.add(subpath)
-                paths_list.append(subpath)
-
-    return paths_list
 
 
 def main():
@@ -57,8 +36,7 @@ def main():
     unsortable = 0
     unchanged = 0
 
-    paths = _find_files(args.files)
-    for path in paths:
+    for path in find_python_files(args.files):
         errors = False
 
         original_bytes = path.read_bytes()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -7,10 +7,6 @@ import pytest
 from ssort._files import is_ignored
 
 
-def _is_ignored(path: str) -> bool:
-    return is_ignored(pathlib.Path(path))
-
-
 def test_ignore_git(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -19,20 +15,20 @@ def test_ignore_git(
     (tmp_path / ".git").mkdir()
     (tmp_path / ".gitignore").write_text("ignored")
 
-    assert not _is_ignored("src")
-    assert not _is_ignored("src/main.py")
+    assert not is_ignored("src")
+    assert not is_ignored("src/main.py")
 
-    assert _is_ignored("ignored")
-    assert _is_ignored("ignored/main.py")
+    assert is_ignored("ignored")
+    assert is_ignored("ignored/main.py")
 
-    assert _is_ignored("src/ignored")
-    assert _is_ignored("src/ignored/main.py")
+    assert is_ignored("src/ignored")
+    assert is_ignored("src/ignored/main.py")
 
-    assert not _is_ignored("../ignored")
-    assert not _is_ignored("../ignored/main.py")
+    assert not is_ignored("../ignored")
+    assert not is_ignored("../ignored/main.py")
 
-    assert _is_ignored(f"../{tmp_path.name}/ignored")
-    assert _is_ignored(f"../{tmp_path.name}/ignored/main.py")
+    assert is_ignored(f"../{tmp_path.name}/ignored")
+    assert is_ignored(f"../{tmp_path.name}/ignored/main.py")
 
 
 def test_ignore_git_with_no_repo(
@@ -42,20 +38,20 @@ def test_ignore_git_with_no_repo(
 
     (tmp_path / ".gitignore").write_text("ignored")
 
-    assert not _is_ignored("src")
-    assert not _is_ignored("src/main.py")
+    assert not is_ignored("src")
+    assert not is_ignored("src/main.py")
 
-    assert _is_ignored("ignored")
-    assert _is_ignored("ignored/main.py")
+    assert is_ignored("ignored")
+    assert is_ignored("ignored/main.py")
 
-    assert _is_ignored("src/ignored")
-    assert _is_ignored("src/ignored/main.py")
+    assert is_ignored("src/ignored")
+    assert is_ignored("src/ignored/main.py")
 
-    assert not _is_ignored("../ignored")
-    assert not _is_ignored("../ignored/main.py")
+    assert not is_ignored("../ignored")
+    assert not is_ignored("../ignored/main.py")
 
-    assert _is_ignored(f"../{tmp_path.name}/ignored")
-    assert _is_ignored(f"../{tmp_path.name}/ignored/main.py")
+    assert is_ignored(f"../{tmp_path.name}/ignored")
+    assert is_ignored(f"../{tmp_path.name}/ignored/main.py")
 
 
 def test_ignore_git_in_subdirectory(
@@ -69,46 +65,46 @@ def test_ignore_git_in_subdirectory(
     (tmp_path / "sub").mkdir()
     (tmp_path / "sub" / ".gitignore").write_text("child")
 
-    assert not _is_ignored("src")
-    assert not _is_ignored("src/main.py")
-    assert not _is_ignored("sub/src")
-    assert not _is_ignored("sub/src/main.py")
+    assert not is_ignored("src")
+    assert not is_ignored("src/main.py")
+    assert not is_ignored("sub/src")
+    assert not is_ignored("sub/src/main.py")
 
-    assert _is_ignored("parent")
-    assert _is_ignored("parent/main.py")
-    assert _is_ignored("sub/parent")
-    assert _is_ignored("sub/parent/main.py")
+    assert is_ignored("parent")
+    assert is_ignored("parent/main.py")
+    assert is_ignored("sub/parent")
+    assert is_ignored("sub/parent/main.py")
 
-    assert _is_ignored("src/parent")
-    assert _is_ignored("src/parent/main.py")
-    assert _is_ignored("sub/src/parent")
-    assert _is_ignored("sub/src/parent/main.py")
+    assert is_ignored("src/parent")
+    assert is_ignored("src/parent/main.py")
+    assert is_ignored("sub/src/parent")
+    assert is_ignored("sub/src/parent/main.py")
 
-    assert not _is_ignored("../parent")
-    assert not _is_ignored("../parent/main.py")
-    assert not _is_ignored("../sub/parent")
-    assert not _is_ignored("../sub/parent/main.py")
+    assert not is_ignored("../parent")
+    assert not is_ignored("../parent/main.py")
+    assert not is_ignored("../sub/parent")
+    assert not is_ignored("../sub/parent/main.py")
 
-    assert _is_ignored(f"../{tmp_path.name}/parent")
-    assert _is_ignored(f"../{tmp_path.name}/parent/main.py")
-    assert _is_ignored(f"../{tmp_path.name}/sub/parent")
-    assert _is_ignored(f"../{tmp_path.name}/sub/parent/main.py")
+    assert is_ignored(f"../{tmp_path.name}/parent")
+    assert is_ignored(f"../{tmp_path.name}/parent/main.py")
+    assert is_ignored(f"../{tmp_path.name}/sub/parent")
+    assert is_ignored(f"../{tmp_path.name}/sub/parent/main.py")
 
-    assert not _is_ignored("child")
-    assert not _is_ignored("child/main.py")
-    assert _is_ignored("sub/child")
-    assert _is_ignored("sub/child/main.py")
+    assert not is_ignored("child")
+    assert not is_ignored("child/main.py")
+    assert is_ignored("sub/child")
+    assert is_ignored("sub/child/main.py")
 
-    assert not _is_ignored("src/child")
-    assert not _is_ignored("src/child/main.py")
-    assert _is_ignored("sub/src/child")
-    assert _is_ignored("sub/src/child/main.py")
+    assert not is_ignored("src/child")
+    assert not is_ignored("src/child/main.py")
+    assert is_ignored("sub/src/child")
+    assert is_ignored("sub/src/child/main.py")
 
-    assert not _is_ignored("sub/../child")
-    assert not _is_ignored("sub/../child/main.py")
+    assert not is_ignored("sub/../child")
+    assert not is_ignored("sub/../child/main.py")
 
-    assert _is_ignored(f"../{tmp_path.name}/sub/child")
-    assert _is_ignored(f"../{tmp_path.name}/sub/child/main.py")
+    assert is_ignored(f"../{tmp_path.name}/sub/child")
+    assert is_ignored(f"../{tmp_path.name}/sub/child/main.py")
 
 
 def test_ignore_git_in_working_subdirectory(
@@ -120,23 +116,23 @@ def test_ignore_git_in_working_subdirectory(
     (tmp_path / "sub").mkdir()
     monkeypatch.chdir(tmp_path / "sub")
 
-    assert not _is_ignored("src")
-    assert not _is_ignored("src/main.py")
+    assert not is_ignored("src")
+    assert not is_ignored("src/main.py")
 
-    assert _is_ignored("ignored")
-    assert _is_ignored("ignored/main.py")
+    assert is_ignored("ignored")
+    assert is_ignored("ignored/main.py")
 
-    assert _is_ignored("src/ignored")
-    assert _is_ignored("src/ignored/main.py")
+    assert is_ignored("src/ignored")
+    assert is_ignored("src/ignored/main.py")
 
-    assert _is_ignored("../ignored")
-    assert _is_ignored("../ignored/main.py")
+    assert is_ignored("../ignored")
+    assert is_ignored("../ignored/main.py")
 
-    assert _is_ignored("../sub/ignored")
-    assert _is_ignored("../sub/ignored/main.py")
+    assert is_ignored("../sub/ignored")
+    assert is_ignored("../sub/ignored/main.py")
 
-    assert not _is_ignored("../../ignored")
-    assert not _is_ignored("../../ignored/main.py")
+    assert not is_ignored("../../ignored")
+    assert not is_ignored("../../ignored/main.py")
 
 
 def test_ignore_git_in_working_parent_directory(
@@ -148,17 +144,17 @@ def test_ignore_git_in_working_parent_directory(
     (tmp_path / "sub" / ".git").mkdir()
     (tmp_path / "sub" / ".gitignore").write_text("ignored")
 
-    assert not _is_ignored("ignored")
-    assert not _is_ignored("ignored/main.py")
+    assert not is_ignored("ignored")
+    assert not is_ignored("ignored/main.py")
 
-    assert _is_ignored("sub/ignored")
-    assert _is_ignored("sub/ignored/main.py")
+    assert is_ignored("sub/ignored")
+    assert is_ignored("sub/ignored/main.py")
 
-    assert _is_ignored("sub/src/ignored")
-    assert _is_ignored("sub/src/ignored/main.py")
+    assert is_ignored("sub/src/ignored")
+    assert is_ignored("sub/src/ignored/main.py")
 
-    assert not _is_ignored("sub/../ignored")
-    assert not _is_ignored("sub/../ignored/main.py")
+    assert not is_ignored("sub/../ignored")
+    assert not is_ignored("sub/../ignored/main.py")
 
 
 def test_ignore_git_subdirectory_pattern(
@@ -171,11 +167,11 @@ def test_ignore_git_subdirectory_pattern(
 
     (tmp_path / "sub").mkdir()
 
-    assert not _is_ignored("sub")
-    assert not _is_ignored("sub/main.py")
+    assert not is_ignored("sub")
+    assert not is_ignored("sub/main.py")
 
-    assert _is_ignored("sub/ignored")
-    assert _is_ignored("sub/ignored/main.py")
+    assert is_ignored("sub/ignored")
+    assert is_ignored("sub/ignored/main.py")
 
 
 def test_ignore_git_symlink_recursive(
@@ -189,13 +185,13 @@ def test_ignore_git_symlink_recursive(
     (tmp_path / "dir").mkdir()
     (tmp_path / "dir" / "link").symlink_to(tmp_path / "dir")
 
-    assert not _is_ignored("dir")
-    assert not _is_ignored("dir/link")
-    assert not _is_ignored("dir/link/link")
+    assert not is_ignored("dir")
+    assert not is_ignored("dir/link")
+    assert not is_ignored("dir/link/link")
 
-    assert _is_ignored("dir/ignored")
-    assert _is_ignored("dir/link/ignored")
-    assert _is_ignored("dir/link/link/ignored")
+    assert is_ignored("dir/ignored")
+    assert is_ignored("dir/link/ignored")
+    assert is_ignored("dir/link/link/ignored")
 
 
 def test_ignore_git_symlink_outside_repo(
@@ -209,10 +205,10 @@ def test_ignore_git_symlink_outside_repo(
     (tmp_path / "link").mkdir()
     (tmp_path / "repo" / "link").symlink_to(tmp_path / "link")
 
-    assert not _is_ignored("link")
-    assert not _is_ignored("link/main.py")
-    assert _is_ignored("repo/link")
-    assert _is_ignored("repo/link/main.py")
+    assert not is_ignored("link")
+    assert not is_ignored("link/main.py")
+    assert is_ignored("repo/link")
+    assert is_ignored("repo/link/main.py")
 
 
 def test_ignore_symlink_circular(
@@ -223,5 +219,5 @@ def test_ignore_symlink_circular(
     (tmp_path / "link1").symlink_to(tmp_path / "link2")
     (tmp_path / "link2").symlink_to(tmp_path / "link1")
 
-    assert not _is_ignored("link1")
-    assert not _is_ignored("link2")
+    assert not is_ignored("link1")
+    assert not is_ignored("link2")

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from ssort._files import is_ignored
+
+
+def _is_ignored(path: str) -> bool:
+    return is_ignored(pathlib.Path(path))
+
+
+def test_ignore_git(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".gitignore").write_text("ignored")
+
+    assert not _is_ignored("src")
+    assert not _is_ignored("src/main.py")
+
+    assert _is_ignored("ignored")
+    assert _is_ignored("ignored/main.py")
+
+    assert _is_ignored("src/ignored")
+    assert _is_ignored("src/ignored/main.py")
+
+    assert not _is_ignored("../ignored")
+    assert not _is_ignored("../ignored/main.py")
+
+    assert _is_ignored(f"../{tmp_path.name}/ignored")
+    assert _is_ignored(f"../{tmp_path.name}/ignored/main.py")
+
+
+def test_ignore_git_with_no_git_directory(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / ".gitignore").write_text("ignored")
+
+    assert not _is_ignored("src")
+    assert not _is_ignored("src/main.py")
+
+    assert _is_ignored("ignored")
+    assert _is_ignored("ignored/main.py")
+
+    assert _is_ignored("src/ignored")
+    assert _is_ignored("src/ignored/main.py")
+
+    assert not _is_ignored("../ignored")
+    assert not _is_ignored("../ignored/main.py")
+
+    assert _is_ignored(f"../{tmp_path.name}/ignored")
+    assert _is_ignored(f"../{tmp_path.name}/ignored/main.py")
+
+
+def test_ignore_git_in_subdirectory(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".gitignore").write_text("parent")
+
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / ".gitignore").write_text("child")
+
+    assert not _is_ignored("src")
+    assert not _is_ignored("src/main.py")
+    assert not _is_ignored("sub/src")
+    assert not _is_ignored("sub/src/main.py")
+
+    assert _is_ignored("parent")
+    assert _is_ignored("parent/main.py")
+    assert _is_ignored("sub/parent")
+    assert _is_ignored("sub/parent/main.py")
+
+    assert _is_ignored("src/parent")
+    assert _is_ignored("src/parent/main.py")
+    assert _is_ignored("sub/src/parent")
+    assert _is_ignored("sub/src/parent/main.py")
+
+    assert not _is_ignored("../parent")
+    assert not _is_ignored("../parent/main.py")
+    assert not _is_ignored("../sub/parent")
+    assert not _is_ignored("../sub/parent/main.py")
+
+    assert _is_ignored(f"../{tmp_path.name}/parent")
+    assert _is_ignored(f"../{tmp_path.name}/parent/main.py")
+    assert _is_ignored(f"../{tmp_path.name}/sub/parent")
+    assert _is_ignored(f"../{tmp_path.name}/sub/parent/main.py")
+
+    assert not _is_ignored("child")
+    assert not _is_ignored("child/main.py")
+    assert _is_ignored("sub/child")
+    assert _is_ignored("sub/child/main.py")
+
+    assert not _is_ignored("src/child")
+    assert not _is_ignored("src/child/main.py")
+    assert _is_ignored("sub/src/child")
+    assert _is_ignored("sub/src/child/main.py")
+
+    assert not _is_ignored("sub/../child")
+    assert not _is_ignored("sub/../child/main.py")
+
+    assert _is_ignored(f"../{tmp_path.name}/sub/child")
+    assert _is_ignored(f"../{tmp_path.name}/sub/child/main.py")
+
+
+def test_ignore_git_in_working_subdirectory(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".gitignore").write_text("ignored")
+
+    (tmp_path / "sub").mkdir()
+    monkeypatch.chdir(tmp_path / "sub")
+
+    assert not _is_ignored("src")
+    assert not _is_ignored("src/main.py")
+
+    assert _is_ignored("ignored")
+    assert _is_ignored("ignored/main.py")
+
+    assert _is_ignored("src/ignored")
+    assert _is_ignored("src/ignored/main.py")
+
+    assert _is_ignored("../ignored")
+    assert _is_ignored("../ignored/main.py")
+
+    assert _is_ignored("../sub/ignored")
+    assert _is_ignored("../sub/ignored/main.py")
+
+    assert not _is_ignored("../../ignored")
+    assert not _is_ignored("../../ignored/main.py")
+
+
+def test_ignore_git_in_working_parent_directory(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / ".git").mkdir()
+    (tmp_path / "sub" / ".gitignore").write_text("ignored")
+
+    assert not _is_ignored("ignored")
+    assert not _is_ignored("ignored/main.py")
+
+    assert _is_ignored("sub/ignored")
+    assert _is_ignored("sub/ignored/main.py")
+
+    assert _is_ignored("sub/src/ignored")
+    assert _is_ignored("sub/src/ignored/main.py")
+
+    assert not _is_ignored("sub/../ignored")
+    assert not _is_ignored("sub/../ignored/main.py")
+
+
+def test_ignore_symlink_recursive(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / "dir").mkdir()
+    (tmp_path / "dir" / "link").symlink_to(tmp_path / "dir")
+
+    # Just make sure recursive symlinks don't cause unbounded recursion.
+    assert not _is_ignored("dir")
+    assert not _is_ignored("dir/link")
+    assert not _is_ignored("dir/link/link")
+
+
+def test_ignore_symlink_circular(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    (tmp_path / "link1").symlink_to(tmp_path / "link2")
+    (tmp_path / "link2").symlink_to(tmp_path / "link1")
+
+    # Unresolvable links should be ignored.
+    assert _is_ignored("link1")
+    assert _is_ignored("link2")


### PR DESCRIPTION
I ended up scrapping the `_files` module pulled in from `black` because I ran into a number of issues:

1. There is a lot of code which is specific to `black` and not applicable to `ssort`.
2. `.gitignore` files outside of the root are ignored as you mentioned in #45
3. Only a single project root is allowed.
4. Symbolic links can't be resolved outside the project root.
5. And, generally, there was a lot of complexity which was unnecessary for just this single feature.

The new `_files` implementation I put together solves all the above issues.