### PR TITLE
Improve file related error messages

### DIFF
--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -57,7 +57,7 @@ def find_python_files(
     paths_set = set()
     for pattern in patterns:
         path = pathlib.Path(pattern)
-        if path.suffix == ".py":
+        if not path.is_dir():
             subpaths = [path]
         else:
             subpaths = [

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -63,7 +63,7 @@ def find_python_files(
             subpaths = [
                 subpath
                 for subpath in path.glob("**/*.py")
-                if not is_ignored(subpath)
+                if not is_ignored(subpath) and subpath.is_file()
             ]
 
         for subpath in sorted(subpaths):

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -142,9 +142,7 @@ def main():
         if unsortable:
             summary.append(f"{_fmt_count(unsortable)} would not be sortable")
         if not unsorted and not unchanged and not unsortable:
-            summary.append(
-                "No files are present to be formatted. Nothing to do."
-            )
+            summary.append("No files are present to be sorted. Nothing to do.")
 
         sys.stderr.write(", ".join(summary) + "\n")
 
@@ -167,9 +165,7 @@ def main():
         if unsortable:
             summary.append(f"{_fmt_count_were(unsortable)} not sortable")
         if not unsorted and not unchanged and not unsortable:
-            summary.append(
-                "No files are present to be formatted. Nothing to do."
-            )
+            summary.append("No files are present to be sorted. Nothing to do.")
 
         sys.stderr.write(", ".join(summary) + "\n")
 

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -45,6 +45,14 @@ def main():
             sys.stderr.write(f"ERROR: {str(path)!r} does not exist\n")
             unsortable += 1
             continue
+        except IsADirectoryError:
+            sys.stderr.write(f"ERROR: {str(path)!r} is a directory\n")
+            unsortable += 1
+            continue
+        except PermissionError:
+            sys.stderr.write(f"ERROR: {str(path)!r} is not readable\n")
+            unsortable += 1
+            continue
 
         # The logic for converting from bytes to text is duplicated in `ssort`
         # and here because we need access to the text to be able to compute a

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -41,7 +41,7 @@ def main():
 
         try:
             original_bytes = path.read_bytes()
-        except FileNotFoundError as exc:
+        except FileNotFoundError:
             sys.stderr.write(f"ERROR: {str(path)!r} does not exist\n")
             unsortable += 1
             continue

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -39,7 +39,12 @@ def main():
     for path in find_python_files(args.files):
         errors = False
 
-        original_bytes = path.read_bytes()
+        try:
+            original_bytes = path.read_bytes()
+        except FileNotFoundError as exc:
+            sys.stderr.write(f"ERROR: {str(path)!r} does not exist\n")
+            unsortable += 1
+            continue
 
         # The logic for converting from bytes to text is duplicated in `ssort`
         # and here because we need access to the text to be able to compute a
@@ -136,6 +141,10 @@ def main():
             summary.append(f"{_fmt_count(unchanged)} would be left unchanged")
         if unsortable:
             summary.append(f"{_fmt_count(unsortable)} would not be sortable")
+        if not unsorted and not unchanged and not unsortable:
+            summary.append(
+                "No files are present to be formatted. Nothing to do."
+            )
 
         sys.stderr.write(", ".join(summary) + "\n")
 
@@ -157,6 +166,10 @@ def main():
             summary.append(f"{_fmt_count_were(unchanged)} left unchanged")
         if unsortable:
             summary.append(f"{_fmt_count_were(unsortable)} not sortable")
+        if not unsorted and not unchanged and not unsortable:
+            summary.append(
+                "No files are present to be formatted. Nothing to do."
+            )
 
         sys.stderr.write(", ".join(summary) + "\n")
 

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -298,3 +298,48 @@ def test_ssort_character_error(tmp_path):
     actual_msgs, actual_status = _ssort(tmp_path)
 
     assert (actual_msgs, actual_status) == (expected_msgs, expected_status)
+
+
+def test_ssort_empty_dir(tmp_path):
+    expected_msgs = ["No files are present to be sorted. Nothing to do.\n"]
+    expected_status = 0
+
+    actual_msgs, actual_status = _ssort(tmp_path)
+
+    assert (actual_msgs, actual_status) == (expected_msgs, expected_status)
+
+
+def test_ssort_non_existent_file(tmp_path):
+    path = tmp_path / "file.py"
+
+    expected_msgs = [
+        f"ERROR: '{path}' does not exist\n",
+        "1 file was not sortable\n",
+    ]
+    expected_status = 1
+
+    actual_msgs, actual_status = _ssort(path)
+
+    assert (actual_msgs, actual_status) == (expected_msgs, expected_status)
+
+
+def test_ssort_no_py_extension(tmp_path):
+    path = tmp_path / "file"
+    path.write_bytes(_good)
+    expected_msgs = ["1 file was left unchanged\n"]
+    expected_status = 0
+    actual_msgs, actual_status = _ssort(path)
+    assert (actual_msgs, actual_status) == (expected_msgs, expected_status)
+
+
+def test_ssort_unreadable_file(tmp_path):
+    path = tmp_path / "file.py"
+    path.write_bytes(_good)
+    path.chmod(0)
+    expected_msgs = [
+        f"ERROR: '{path}' is not readable\n",
+        "1 file was not sortable\n",
+    ]
+    expected_status = 1
+    actual_msgs, actual_status = _ssort(path)
+    assert (actual_msgs, actual_status) == (expected_msgs, expected_status)


### PR DESCRIPTION
Improves messages in the following cases:
1. A provided file does not exist.
2. A directory was provided but that directory contains no Python files.

Changed behavior:
1. Allow processing of files even if they do not have a `.py` extension.