### PR TITLE
Empty file fix

### DIFF
--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -474,6 +474,9 @@ def ssort(
         on_parse_error(str(exc), lineno=exc.lineno, col_offset=exc.col_offset)
         return text
 
+    if not statements:
+        return text
+
     graph = module_statements_graph(
         statements,
         on_unresolved=on_unresolved,

--- a/tests/test_ssort.py
+++ b/tests/test_ssort.py
@@ -526,3 +526,18 @@ def test_lifecycle_class_private():
     )
     actual = ssort(original)
     assert actual == expected
+
+
+def test_single_comment():
+    original = _clean(
+        """
+        # This is a file with just a single comment!
+        """
+    )
+    expected = _clean(
+        """
+        # This is a file with just a single comment!
+        """
+    )
+    actual = ssort(original)
+    assert actual == expected


### PR DESCRIPTION
Properly handle files with no statements. The existing behavior is to delete everything in the file, including any comments.