### PR TITLE
Wildcard import callback fix

### DIFF
--- a/src/ssort/_exceptions.py
+++ b/src/ssort/_exceptions.py
@@ -24,4 +24,7 @@ class ResolutionError(Exception):
 
 
 class WildcardImportError(Exception):
-    pass
+    def __init__(self, msg, *, lineno, col_offset):
+        super().__init__(msg)
+        self.lineno = lineno
+        self.col_offset = col_offset

--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -415,13 +415,15 @@ def _interpret_on_unresolved_action(on_unresolved):
     return on_unresolved
 
 
-def _on_wildcard_import_ignore(message, **kwargs):
+def _on_wildcard_import_ignore(**kwargs):
     pass
 
 
-def _on_wildcard_import_raise(message, *, lineno, col_offset, **kwargs):
+def _on_wildcard_import_raise(*, lineno, col_offset, **kwargs):
     raise WildcardImportError(
-        "can't reliably determine dependencies on * import"
+        "can't reliably determine dependencies on * import",
+        lineno=lineno,
+        col_offset=col_offset,
     )
 
 

--- a/tests/test_error_hooks.py
+++ b/tests/test_error_hooks.py
@@ -164,7 +164,7 @@ def test_on_wildcard_import_raise():
 
 
 def test_on_wildcard_import_ignore():
-    original = "from module import *"
+    original = "from module import *\n"
 
     actual = ssort(original, on_wildcard_import="ignore")
 


### PR DESCRIPTION
Fixed signature of `_on_wildcard_import_raise` and `_on_wildcard_import_ignore`. Existing behavior causes a `TypeError` to be raised if a wildcard import is encountered and either `on_wildcard_import="ignore"` or `on_wildcard_import="raise"` is specified.