### PR TITLE
Remove unused `__main__` module.

### DIFF
--- a/src/ssort/__main__.py
+++ b/src/ssort/__main__.py
@@ -1,3 +1,0 @@
-from ssort._main import main
-
-main()


### PR DESCRIPTION
This is impossible to call because of the src wrapper dir, and is obviated by the entry point configuration in setup.cfg.