### PR TITLE
Add support for detecting and preserving different newline types

### DIFF
--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -1,5 +1,6 @@
 import argparse
 import difflib
+import re
 import sys
 
 from ssort._exceptions import UnknownEncodingError
@@ -126,7 +127,11 @@ def main():
                 )
             else:
                 sys.stderr.write(f"Sorting {str(path)!r}\n")
-                path.write_text(updated, encoding=encoding, newline=newline)
+                if newline != "\n":
+                    # `newline` argument to `write_text` not supported in python
+                    # 3.8 and earlier.
+                    updated = re.sub("\n", newline, updated)
+                path.write_text(updated, encoding=encoding)
         else:
             unchanged += 1
 

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -5,7 +5,7 @@ import sys
 from ssort._exceptions import UnknownEncodingError
 from ssort._files import find_python_files
 from ssort._ssort import ssort
-from ssort._utils import detect_encoding
+from ssort._utils import detect_encoding, detect_newline, normalize_newlines
 
 
 def main():
@@ -75,6 +75,9 @@ def main():
             unsortable += 1
             continue
 
+        newline = detect_newline(original)
+        original = normalize_newlines(original)
+
         def _on_parse_error(message, *, lineno, col_offset, **kwargs):
             nonlocal errors
             errors = True
@@ -123,7 +126,7 @@ def main():
                 )
             else:
                 sys.stderr.write(f"Sorting {str(path)!r}\n")
-                path.write_text(updated, encoding=encoding)
+                path.write_text(updated, encoding=encoding, newline=newline)
         else:
             unchanged += 1
 

--- a/src/ssort/_main.py
+++ b/src/ssort/_main.py
@@ -127,11 +127,18 @@ def main():
                 )
             else:
                 sys.stderr.write(f"Sorting {str(path)!r}\n")
+
+                # The logic for converting from bytes to text is duplicated in
+                # `ssort` and here because we need access to the text to be able
+                # to compute a diff at the end.
+                # We rename a little prematurely to avoid shadowing `updated`,
+                # which we use later for printing the diff.
+                updated_bytes = updated
                 if newline != "\n":
-                    # `newline` argument to `write_text` not supported in python
-                    # 3.8 and earlier.
-                    updated = re.sub("\n", newline, updated)
-                path.write_text(updated, encoding=encoding)
+                    updated_bytes = re.sub("\n", newline, updated_bytes)
+                updated_bytes = updated_bytes.encode(encoding)
+
+                path.write_bytes(updated_bytes)
         else:
             unchanged += 1
 

--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -1,4 +1,5 @@
 import ast
+import re
 import sys
 
 from ssort._dependencies import (
@@ -24,7 +25,12 @@ from ssort._statements import (
     statement_node,
     statement_text,
 )
-from ssort._utils import detect_encoding, sort_key_from_iter
+from ssort._utils import (
+    detect_encoding,
+    detect_newline,
+    normalize_newlines,
+    sort_key_from_iter,
+)
 
 SPECIAL_PROPERTIES = [
     "__doc__",
@@ -470,6 +476,9 @@ def ssort(
         on_decoding_error(str(exc))
         return text
 
+    newline = detect_newline(text)
+    text = normalize_newlines(text)
+
     try:
         statements = list(parse(text, filename=filename))
     except ParseError as exc:
@@ -499,6 +508,8 @@ def ssort(
     if output:
         output += "\n"
 
+    if newline != "\n":
+        output = re.sub("\n", newline, output)
     if encoding is not None:
         output = output.encode(encoding)
     return output

--- a/src/ssort/_utils.py
+++ b/src/ssort/_utils.py
@@ -60,3 +60,24 @@ def detect_encoding(bytestring):
             exc.msg, encoding=re.match("unknown encoding: (.*)", exc.msg)[1]
         ) from exc
     return encoding
+
+
+_NEWLINE_RE = re.compile("(\r\n)|(\r)|(\n)")
+
+
+def detect_newline(text):
+    """
+    Detects the newline character used in a source file based on the first
+    occurence of '\\n', '\\r' or '\\r\\n'.
+    """
+    match = re.search(_NEWLINE_RE, text)
+    if match is None:
+        return "\n"
+    return match[0]
+
+
+def normalize_newlines(text):
+    """
+    Replaces all occurrences of '\r' and '\\r\\n' with \n.
+    """
+    return re.sub(_NEWLINE_RE, "\n", text)

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -1,3 +1,4 @@
+import pathlib
 import subprocess
 import sys
 
@@ -319,6 +320,27 @@ def test_ssort_character_error(ssort, tmp_path):
     actual_msgs, actual_status = ssort(tmp_path)
 
     assert (actual_msgs, actual_status) == (expected_msgs, expected_status)
+
+
+def test_ssort_preserve_crlf_endlines(ssort, tmp_path):
+    input = b"a = b\r\nb = 4"
+    expected_output = b"b = 4\r\na = b\r\n"
+
+    paths = _write_fixtures(tmp_path, [input])
+
+    expected_msgs = [
+        f"Sorting {paths[0]!r}\n",
+        "1 file was resorted\n",
+    ]
+    expected_status = 0
+
+    actual_msgs, actual_status = ssort(tmp_path)
+
+    assert actual_msgs == expected_msgs
+    assert actual_status == expected_status
+
+    (output,) = [pathlib.Path(path).read_bytes() for path in paths]
+    assert output == expected_output
 
 
 def test_ssort_empty_dir(ssort, tmp_path):

--- a/tests/test_ssort.py
+++ b/tests/test_ssort.py
@@ -541,3 +541,19 @@ def test_single_comment():
     )
     actual = ssort(original)
     assert actual == expected
+
+
+def test_ssort_preserve_crlf_endlines_bytes():
+    original = b"a = b\r\nb = 4"
+    expected = b"b = 4\r\na = b\r\n"
+
+    actual = ssort(original)
+    assert actual == expected
+
+
+def test_ssort_preserve_crlf_endlines_str():
+    original = "a = b\r\nb = 4"
+    expected = "b = 4\r\na = b\r\n"
+
+    actual = ssort(original)
+    assert actual == expected


### PR DESCRIPTION
I think this should resolve #61.  Same problem with duplicate implementations as with encoding, only slightly worse because the newline detection logic will always run twice.  Should only result in a single wasted `re.search` scan over the first line of the file.