### PR TITLE
Change pre-commit `rev:` to `master`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,17 +114,17 @@ and registering ssort in your `.pre-commit-config.yaml`.
   repos:
   # ...
   - repo: https://github.com/bwhmather/ssort
-    rev: 0.11.5
+    rev: master
     hooks:
     - id: ssort
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: master
     hooks:
     - id: isort
       name: isort (python)
       args: [--profile=black]
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: master
     hooks:
     - id: black
 


### PR DESCRIPTION
Thanks a ton for your work!

Implementing this means one less thing to keep up-to-date in the readme. Current example fails:

```
[INFO] Initializing environment for https://github.com/bwhmather/ssort.
An unexpected error has occurred: CalledProcessError: command: ('/usr/bin/git', 'checkout', '0.11.5')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    error: pathspec '0.11.5' did not match any file(s) known to git
```

Whereas new example running, pre-commit automatically informs the user:

```
[WARNING] The 'rev' field of repo 'https://github.com/bwhmather/ssort' appears to be a mutable reference (moving tag / branch).  
Mutable references are never updated after first install and are not supported.  
See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  
Hint: `pre-commit autoupdate` often fixes this.
```

And `pre-commit autoupdate` indeed fixes it.