### PR TITLE
Duplicate basepython entry to avoid conflict with envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py38,py39,py310,py311,black,isort,ssort,pyflakes,pylint,mypy
 isolated_build = true
 
 [testenv]
-basepython = py311
 deps =
     pytest
     pyyaml==6.0
@@ -11,6 +10,7 @@ commands =
     pytest -vv tests/
 
 [testenv:black]
+basepython = py311
 deps =
     black
 skip_install = True
@@ -18,6 +18,7 @@ commands =
     black --check --diff .
 
 [testenv:isort]
+basepython = py311
 deps =
     isort
 skip_install = True
@@ -25,10 +26,12 @@ commands =
     isort --check-only --diff .
 
 [testenv:ssort]
+basepython = py311
 commands =
     ssort --check --diff src/ tests/
 
 [testenv:pyflakes]
+basepython = py311
 deps =
     pyflakes
 skip_install = True
@@ -36,6 +39,7 @@ commands =
     pyflakes src/ tests/
 
 [testenv:pylint]
+basepython = py311
 deps =
     pytest
     pyyaml==6.0
@@ -46,6 +50,7 @@ commands =
     pylint -E src/ tests/
 
 [testenv:mypy]
+basepython = py311
 deps =
     mypy
     pytest


### PR DESCRIPTION
Moving `basepython` setting into base `[testenv]` is causing my version of tox to complain about conflicts with the python versions declared in `envlist`.  Partially rolling back.