### PR TITLE
Backwards compatible packaging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         pip install black
     - name: Run black
       run: |
-        black --check --diff .
+        black --check --diff setup.py src/ tests/
 
   isort:
     name: "ISort"
@@ -85,7 +85,7 @@ jobs:
         pip install isort
     - name: Run isort
       run: |
-        isort --check-only --diff .
+        isort --check-only --diff setup.py src/ tests/
 
   ssort:
     name: "SSort"
@@ -102,7 +102,7 @@ jobs:
         pip install -e .
     - name: Run ssort
       run: |
-        ssort --check --diff src/ tests/
+        ssort --check --diff setup.py src/ tests/
 
   pyflakes:
     name: "PyFlakes"
@@ -119,7 +119,7 @@ jobs:
         pip install pyflakes
     - name: Run pyflakes
       run: |
-        pyflakes src/ tests/
+        pyflakes setup.py src/ tests/
 
   pylint:
     name: "PyLint"
@@ -139,7 +139,7 @@ jobs:
         pip install pylint
     - name: Run pylint
       run: |
-        pylint -E src/ tests/
+        pylint -E setup.py src/ tests/
 
   mypy:
     name: "Mypy"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+# Exclude everything by default.  Require individual files to be whitelisted.
+global-exclude *
+
+# Include python files.
+recursive-include src *.py
+
+# Include coniguration files.
+include setup.cfg
+include pyproject.toml
+
+# Include documentation.
+include README.rst LICENSE

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ global-exclude *
 recursive-include src *.py
 
 # Include coniguration files.
+include setup.py
 include setup.cfg
 include pyproject.toml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,48 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [
-    "setuptools>=61.2"
-]
-
-[project]
-authors = [
-    {email = "bwhmather@bwhmather.com", name = "Ben Mather"}
-]
-classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Environment :: Console",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python",
-    "Topic :: Software Development :: Libraries :: Python Modules",
-    "Topic :: Software Development :: Quality Assurance"
-]
-dependencies = [
-    "pathspec >=0.9.0"
-]
-description = "The python statement sorter"
-dynamic = [
-    "version"
-]
-maintainers = [
-    {email = "bwhmather@bwhmather.com", name = "Ben Mather"}
-]
-name = "ssort"
-readme = "README.rst"
-requires-python = ">=3.8"
-
-[project.license]
-text = "MIT"
-
-[project.scripts]
-ssort = "ssort._main:main"
-
-[project.urls]
-Homepage = "https://github.com/bwhmather/ssort"
+requires = ["setuptools"]
 
 [tool.black]
 force-exclude = 'test_data/samples/*'
@@ -64,14 +22,3 @@ exclude = "test_data/samples/*"
 ignore_missing_imports = true
 module = "pathspec"
 
-[tool.setuptools]
-include-package-data = false
-license-files = [
-    "LICENSE"
-]
-
-[tool.setuptools.dynamic.version]
-attr = "ssort.__version__"
-
-[tool.setuptools.packages.find]
-where = ["src"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,43 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+name = ssort
+version = attr: ssort.__version__
+license = MIT
+license_file = LICENSE
+description = The python statement sorter
+long_description = file: README.rst
+author = Ben Mather
+author_email = bwhmather@bwhmather.com
+maintainer = Ben Mather
+maintainer_email = bwhmather@bwhmather.com
+url = https://github.com/bwhmather/ssort
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Software Development :: Quality Assurance
+
+[options]
+package_dir=
+    =src
+packages = find:
+
+install_requires =
+    pathspec >=0.9.0
+python_requires = >=3.8
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    ssort = ssort._main:main

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    setup()

--- a/tox.ini
+++ b/tox.ini
@@ -15,25 +15,25 @@ deps =
     black
 skip_install = True
 commands =
-    black --check --diff .
+    black --check --diff setup.py src/ tests/
 
 [testenv:isort]
 deps =
     isort
 skip_install = True
 commands =
-    isort --check-only --diff .
+    isort --check-only --diff setup.py src/ tests/
 
 [testenv:ssort]
 commands =
-    ssort --check --diff src/ tests/
+    ssort --check --diff setup.py src/ tests/
 
 [testenv:pyflakes]
 deps =
     pyflakes
 skip_install = True
 commands =
-    pyflakes src/ tests/
+    pyflakes setup.py src/ tests/
 
 [testenv:pylint]
 deps =
@@ -43,7 +43,7 @@ deps =
 extras=
     test
 commands =
-    pylint -E src/ tests/
+    pylint -E setup.py src/ tests/
 
 [testenv:mypy]
 deps =


### PR DESCRIPTION
This PR switches to a hybrid `pyproject.toml`/`setup.py`/`setup.cfg` that should work with versions of setuptools at least as far back as 39.0 (required for CentOS 7), and probably older.  It retains the `[build-system]` section in `pyproject.toml` and so should now also be useable by newer dependency management tools that won't support `setup.py`.

As part of this had to introduce a `MANIFEST.in`, and therefore have taken the effort of excluding anything we don't need from the sdist.