### PR TITLE
Build and release wheels to PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install build
     - name: Build package
-      run: python -m build --sdist
+      run: python -m build
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,6 @@ Homepage = "https://github.com/bwhmather/ssort"
 force-exclude = 'test_data/samples/*'
 line_length = 79
 
-[tool.distutils.bdist_wheel]
-universal = 1
-
 [tool.isort]
 extend_skip = ["test_data/samples"]
 line_length = 79


### PR DESCRIPTION
My earlier concerns about build-system requirements in sdists are a complete non-issue if we distribute wheels instead.  Wheels just contain the files to install and a little bit of metadata (essentially the contents of the `project` section in `pyproject.toml`, the `LICENSE` and the `README`).  Building both fixes everything.