### PR TITLE
Don't reformat classes if statement order unchanged

### DIFF
--- a/src/ssort/_ssort.py
+++ b/src/ssort/_ssort.py
@@ -229,7 +229,9 @@ def _statement_binding_sort_key(binding_key):
 
 
 def _statement_text_sorted_class(statement):
-    head_text, statements = split_class(statement)
+    head_text, unsorted_statements = split_class(statement)
+
+    statements = list(unsorted_statements)
 
     # Take a snapshot of any hard dependencies between statements so that we can
     # restore them later.
@@ -316,6 +318,9 @@ def _statement_text_sorted_class(statement):
     sorted_statements = topological_sort(
         sorted_statements, graph=runtime_graph
     )
+
+    if sorted_statements == unsorted_statements:
+        return statement.text
 
     return (
         head_text

--- a/tests/test_ssort.py
+++ b/tests/test_ssort.py
@@ -678,3 +678,19 @@ def test_ssort_self_positional_only():
     )
     actual = ssort(original)
     assert actual == expected
+
+
+def test_single_line_dummy_function():
+    original = "def fun(): ...\n"
+    expected = "def fun(): ...\n"
+
+    actual = ssort(original)
+    assert actual == expected
+
+
+def test_single_line_dummy_class():
+    original = "class Class: ...\n"
+    expected = "class Class: ...\n"
+
+    actual = ssort(original)
+    assert actual == expected


### PR DESCRIPTION
Required for compatibility with black 24 and to comply with out "don't reformat if ordered correctly" rule.  Fixes #113 .