### PR TITLE
Support traversal of TypeAlias for Python 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     name: "Unit Tests"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         runs-on: ["ubuntu-22.04", "windows-2019", "macos-11"]
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pytest
-        pip install pyyaml==6.0
+        pip install pyyaml==6.0.1
         pip install -e .[test]
     - name: Run tests
       run: |
@@ -34,15 +34,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install pytest pytest-cov coveralls
-        pip install pyyaml==6.0
+        pip install pyyaml==6.0.1
         pip install -e .[test]
     - name: Run tests
       run: |
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -75,10 +75,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -109,10 +109,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -126,16 +126,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v2
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .[test]
         pip install pytest
-        pip install pyyaml==6.0
+        pip install pyyaml==6.0.1
         pip install pylint
     - name: Run pylint
       run: |
@@ -146,16 +146,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install mypy
           pip install pytest
-          pip install pyyaml==6.0
+          pip install pyyaml==6.0.1
           pip install types-PyYAML
           pip install types-setuptools
       - name: Run mypy

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: 3.11
+        python-version: 3.12
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/src/ssort/_ast.py
+++ b/src/ssort/_ast.py
@@ -496,3 +496,31 @@ def _iter_child_nodes_of_type_ignore(
     node: ast.TypeIgnore,
 ) -> Iterable[ast.AST]:
     return ()
+
+
+if sys.version_info >= (3, 12):
+
+    @iter_child_nodes.register(ast.TypeAlias)
+    def _iter_child_nodes_of_type_alias(
+        node: ast.TypeAlias,
+    ) -> Iterable[ast.AST]:
+        yield node.name
+        yield from node.type_params
+        yield node.value
+
+    @iter_child_nodes.register(ast.TypeVar)
+    def _iter_child_nodes_of_type_var(node: ast.TypeVar) -> Iterable[ast.AST]:
+        if node.bound is not None:
+            yield node.bound
+
+    @iter_child_nodes.register(ast.ParamSpec)
+    def _iter_child_nodes_of_param_spec(
+        node: ast.ParamSpec,
+    ) -> Iterable[ast.AST]:
+        return ()
+
+    @iter_child_nodes.register(ast.TypeVarTuple)
+    def _iter_child_nodes_of_type_var_tuple(
+        node: ast.TypeVarTuple,
+    ) -> Iterable[ast.AST]:
+        return ()

--- a/src/ssort/_ast.py
+++ b/src/ssort/_ast.py
@@ -50,6 +50,8 @@ def _iter_child_nodes_of_function_def(
     if node.returns is not None:
         yield node.returns
     yield from node.body
+    if sys.version_info >= (3, 12):
+        yield from node.type_params
 
 
 @iter_child_nodes.register(ast.ClassDef)
@@ -58,6 +60,8 @@ def _iter_child_nodes_of_class_def(node: ast.ClassDef) -> Iterable[ast.AST]:
     yield from node.bases
     yield from node.keywords
     yield from node.body
+    if sys.version_info >= (3, 12):
+        yield from node.type_params
 
 
 @iter_child_nodes.register(ast.Return)

--- a/src/ssort/_parsing.py
+++ b/src/ssort/_parsing.py
@@ -128,6 +128,16 @@ def split_class(statement):
     assert token.type == NAME
 
     token = next(tokens)
+    if token.string == "[":
+        token = next(tokens)
+        depth = 1
+        while depth:
+            if token.string == "[":
+                depth += 1
+            if token.string == "]":
+                depth -= 1
+            token = next(tokens)
+
     if token.string == "(":
         token = next(tokens)
         depth = 1

--- a/src/ssort/_parsing.py
+++ b/src/ssort/_parsing.py
@@ -128,25 +128,21 @@ def split_class(statement):
     assert token.type == NAME
 
     token = next(tokens)
-    if token.string == "[":
-        token = next(tokens)
-        depth = 1
-        while depth:
-            if token.string == "[":
-                depth += 1
-            if token.string == "]":
-                depth -= 1
-            token = next(tokens)
 
-    if token.string == "(":
-        token = next(tokens)
-        depth = 1
-        while depth:
-            if token.string == "(":
-                depth += 1
-            if token.string == ")":
-                depth -= 1
+    def _optional_nested_brackets(open: str, close: str):
+        nonlocal token
+        if token.string == open:
             token = next(tokens)
+            depth = 1
+            while depth:
+                if token.string == open:
+                    depth += 1
+                if token.string == close:
+                    depth -= 1
+                token = next(tokens)
+
+    _optional_nested_brackets("[", "]")
+    _optional_nested_brackets("(", ")")
 
     assert token.string == ":"
 

--- a/src/ssort/_parsing.py
+++ b/src/ssort/_parsing.py
@@ -128,21 +128,24 @@ def split_class(statement):
     assert token.type == NAME
 
     token = next(tokens)
-
-    def _optional_nested_brackets(open: str, close: str):
-        nonlocal token
-        if token.string == open:
+    if token.string == "[":
+        token = next(tokens)
+        depth = 1
+        while depth:
+            if token.string == "[":
+                depth += 1
+            if token.string == "]":
+                depth -= 1
             token = next(tokens)
-            depth = 1
-            while depth:
-                if token.string == open:
-                    depth += 1
-                if token.string == close:
-                    depth -= 1
-                token = next(tokens)
-
-    _optional_nested_brackets("[", "]")
-    _optional_nested_brackets("(", ")")
+    if token.string == "(":
+        token = next(tokens)
+        depth = 1
+        while depth:
+            if token.string == "(":
+                depth += 1
+            if token.string == ")":
+                depth -= 1
+            token = next(tokens)
 
     assert token.string == ":"
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1640,7 +1640,7 @@ def test_try_star_binding_walrus_exeption_type():
 
 
 @type_parameter_syntax
-def test_type_var_bindings():
+def test_type_var_recursive_bindings():
     node = _parse("type RecursiveList[T] = T | list[RecursiveList[T]]")
     assert list(get_bindings(node)) == ["RecursiveList"]
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -16,6 +16,11 @@ exception_group = pytest.mark.skipif(
     reason="exception groups were introduced in python 3.11",
 )
 
+type_parameter_syntax = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="type parameter syntax was introduced in python 3.12",
+)
+
 
 def _parse(source):
     source = textwrap.dedent(source)
@@ -1195,3 +1200,21 @@ def test_try_star_requirements():
         "otherwise",
         "finish",
     ]
+
+
+@type_parameter_syntax
+def test_type_var_requirements():
+    node = _parse("type Alias[T: (str, bytes)] = list[T]")
+    assert _dep_names(node) == ["str", "bytes", "list", "T"]
+
+
+@type_parameter_syntax
+def test_param_spec_requirements():
+    node = _parse("type Alias[**P] = Callable[P, int]")
+    assert _dep_names(node) == ["Callable", "P", "int"]
+
+
+@type_parameter_syntax
+def test_type_var_tuple_requirements():
+    node = _parse("type Alias[*Ts] = tuple[*Ts]")
+    assert _dep_names(node) == ["tuple", "Ts"]

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1209,9 +1209,15 @@ def test_type_var_requirements():
 
 
 @type_parameter_syntax
-def test_type_var_requirements_recursive():
+def test_type_var_recursive_requirements():
     node = _parse("type RecursiveList[T] = T | list[RecursiveList[T]]")
     assert _dep_names(node) == ["list"]
+
+
+@type_parameter_syntax
+def test_type_var_scope_requirements():
+    node = _parse("type Alias[S, T: Sequence[S]] = dict[S, T]")
+    assert _dep_names(node) == ["Sequence", "dict"]
 
 
 @type_parameter_syntax
@@ -1244,6 +1250,17 @@ def test_generic_function_requirements():
 
 
 @type_parameter_syntax
+def test_generic_function_scope_requirements():
+    node = _parse(
+        """
+        def func[S, T: Sequence[S]](a: S) -> T:
+            pass
+        """
+    )
+    assert _dep_names(node) == ["Sequence"]
+
+
+@type_parameter_syntax
 def test_generic_class_requirements():
     node = _parse(
         """
@@ -1254,6 +1271,17 @@ def test_generic_class_requirements():
         """
     )
     assert _dep_names(node) == []
+
+
+@type_parameter_syntax
+def test_generic_class_scope_requirements():
+    node = _parse(
+        """
+        class ClassA[S, T: Sequence[S]]:
+            pass
+        """
+    )
+    assert _dep_names(node) == ["Sequence"]
 
 
 @type_parameter_syntax

--- a/tests/test_ssort.py
+++ b/tests/test_ssort.py
@@ -710,6 +710,8 @@ def test_ssort_type_alias():
         """
         from decimal import Decimal
 
+        roundint(3.14)
+        
         def roundint(n: N) -> int:
             return int(round(n))
 
@@ -724,6 +726,52 @@ def test_ssort_type_alias():
 
         def roundint(n: N) -> int:
             return int(round(n))
+            
+        roundint(3.14)
+        """
+    )
+    actual = ssort(original)
+    assert actual == expected
+
+
+@type_parameter_syntax
+def test_ssort_generic_function():
+    original = _clean(
+        """
+        func(4)
+        def func[T](a: T) -> T:
+            return a
+        """
+    )
+    expected = _clean(
+        """
+        def func[T](a: T) -> T:
+            return a
+        func(4)
+        """
+    )
+    actual = ssort(original)
+    assert actual == expected
+
+
+@type_parameter_syntax
+def test_ssort_generic_class():
+    original = _clean(
+        """
+        obj = ClassA[str]()
+        class ClassA[T: (str, bytes)](BaseClass[T]):
+            attr1: T
+        class BaseClass[T]:
+            pass
+        """
+    )
+    expected = _clean(
+        """
+        class BaseClass[T]:
+            pass
+        class ClassA[T: (str, bytes)](BaseClass[T]):
+            attr1: T
+        obj = ClassA[str]()
         """
     )
     actual = ssort(original)

--- a/tests/test_ssort.py
+++ b/tests/test_ssort.py
@@ -1,6 +1,14 @@
+import sys
 import textwrap
 
+import pytest
+
 from ssort import ssort
+
+type_parameter_syntax = pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="type parameter syntax was introduced in python 3.12",
+)
 
 
 def _clean(text):
@@ -692,5 +700,31 @@ def test_single_line_dummy_class():
     original = "class Class: ...\n"
     expected = "class Class: ...\n"
 
+    actual = ssort(original)
+    assert actual == expected
+
+
+@type_parameter_syntax
+def test_ssort_type_alias():
+    original = _clean(
+        """
+        from decimal import Decimal
+
+        def roundint(n: N) -> int:
+            return int(round(n))
+
+        type N = Decimal | float
+        """
+    )
+    expected = _clean(
+        """
+        from decimal import Decimal
+
+        type N = Decimal | float
+
+        def roundint(n: N) -> int:
+            return int(round(n))
+        """
+    )
     actual = ssort(original)
     assert actual == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist = py38,py39,py310,py311,black,isort,ssort,pyflakes,pylint,mypy
+envlist = py38,py39,py310,py311,py312,black,isort,ssort,pyflakes,pylint,mypy
 isolated_build = true
 
 [testenv]
 deps =
     pytest
-    pyyaml==6.0
+    pyyaml==6.0.1
 commands =
     pytest -vv tests/
 
 [testenv:black]
-basepython = py311
+basepython = py312
 deps =
     black
 skip_install = True
@@ -18,7 +18,7 @@ commands =
     black --check --diff .
 
 [testenv:isort]
-basepython = py311
+basepython = py312
 deps =
     isort
 skip_install = True
@@ -26,12 +26,12 @@ commands =
     isort --check-only --diff .
 
 [testenv:ssort]
-basepython = py311
+basepython = py312
 commands =
     ssort --check --diff src/ tests/
 
 [testenv:pyflakes]
-basepython = py311
+basepython = py312
 deps =
     pyflakes
 skip_install = True
@@ -39,10 +39,10 @@ commands =
     pyflakes src/ tests/
 
 [testenv:pylint]
-basepython = py311
+basepython = py312
 deps =
     pytest
-    pyyaml==6.0
+    pyyaml==6.0.1
     pylint
 extras=
     test
@@ -50,11 +50,11 @@ commands =
     pylint -E src/ tests/
 
 [testenv:mypy]
-basepython = py311
+basepython = py312
 deps =
     mypy
     pytest
-    pyyaml==6.0
+    pyyaml==6.0.1
     types-PyYAML
     types-setuptools
 skip_install = True


### PR DESCRIPTION
Also update tox and GitHub Actions to use Python 3.12 by default.
