### PR TITLE
Implement stdin-stdout operation with '-' file argument

### DIFF
--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -57,7 +57,7 @@ def find_python_files(
     paths_set = set()
     for pattern in patterns:
         path = pathlib.Path(pattern)
-        if not path.is_dir():
+        if str(path) == "-" or not path.is_dir():
             subpaths = [path]
         else:
             subpaths = [

--- a/tests/test_executable.py
+++ b/tests/test_executable.py
@@ -420,3 +420,32 @@ def test_ssort_run_module():
     module_output = module_result.stderr.splitlines(keepends=True)
 
     assert module_output == entrypoint_output
+
+
+@pytest.mark.parametrize(
+    ("stdin", "stdout"),
+    (
+        (_unsorted, _good),
+        (_good, _good),
+        (_encoding, _encoding),
+        (_character, _character),
+        (_syntax, _syntax),
+        (_resolution, _resolution),
+        (_double_resolution, _double_resolution),
+    ),
+    ids=(
+        "unsorted",
+        "good",
+        "encoding",
+        "character",
+        "syntax",
+        "resolution",
+        "double_resolution",
+    ),
+)
+def test_ssort_stdin(stdin, stdout):
+    for command in [(sys.executable, "-m", "ssort"), ("ssort",)]:
+        result = subprocess.run(
+            [*command, "-"], capture_output=True, input=stdin
+        )
+        assert result.stdout == stdout


### PR DESCRIPTION
This works well in my casual testing, and can even be used in combination with regular file arguments. ~But I haven't written a formal test for it yet, so I'm marking this as a draft.~

It makes sure to write the stdin to stdout if there's a problem formatting/encoding/decoding, and if no formatting is necessary. This ensures it doesn't delete content when used as one step in a pipeline of successive formatters and linters.