### PR TITLE
Update CI images: latest which cache py 3.8-3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        runs-on: ["ubuntu-22.04", "windows-2019", "macos-11"]
+        runs-on: ["ubuntu-22.04", "windows-2022", "macos-13"]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I noticed the macos actions weren't running with the old macos-11 set, so this bumps macos to 13, and while we're at it Windows to 2022. If you approve the workflow, we can see if the new image actions run without issue. Both of those are documented to cache Python 3.8-3.12 at least, so I don't expect a problem.