### PR TITLE
chore: remove Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     name: "Unit Tests"
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         runs-on: ["ubuntu-22.04", "windows-2022", "macos-13"]
     runs-on: ${{ matrix.runs-on }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Quality Assurance"
@@ -33,7 +34,7 @@ maintainers = [
 ]
 name = "ssort"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.license]
 text = "MIT"

--- a/src/ssort/_ast.py
+++ b/src/ssort/_ast.py
@@ -356,19 +356,6 @@ def _iter_child_nodes_of_slice(node: ast.Slice) -> Iterable[ast.AST]:
         yield node.step
 
 
-if sys.version_info < (3, 9):
-
-    @iter_child_nodes.register(ast.ExtSlice)
-    def _iter_child_nodes_of_ext_slice(
-        node: ast.ExtSlice,
-    ) -> Iterable[ast.AST]:
-        yield from node.dims
-
-    @iter_child_nodes.register(ast.Index)
-    def _iter_child_nodes_of_index(node: ast.Index) -> Iterable[ast.AST]:
-        yield node.value
-
-
 @iter_child_nodes.register(ast.comprehension)
 def _iter_child_nodes_of_comprehension(
     node: ast.comprehension,

--- a/src/ssort/_files.py
+++ b/src/ssort/_files.py
@@ -2,16 +2,15 @@ from __future__ import annotations
 
 import os
 import pathlib
+from functools import cache
 from typing import Iterable
 
 import pathspec
 
-from ssort._utils import memoize
-
 _EMPTY_PATH_SPEC = pathspec.PathSpec([])
 
 
-@memoize
+@cache
 def _is_project_root(path: pathlib.Path) -> bool:
     if path == path.root or path == path.parent:
         return True
@@ -22,7 +21,7 @@ def _is_project_root(path: pathlib.Path) -> bool:
     return False
 
 
-@memoize
+@cache
 def _get_ignore_patterns(path: pathlib.Path) -> pathspec.PathSpec:
     git_ignore = path / ".gitignore"
     if git_ignore.is_file():

--- a/src/ssort/_utils.py
+++ b/src/ssort/_utils.py
@@ -10,8 +10,6 @@ from typing import Any, Callable, Generic, TypeVar
 
 from ssort._exceptions import UnknownEncodingError
 
-memoize = functools.cache
-
 
 def sort_key_from_iter(values):
     index = {statement: index for index, statement in enumerate(values)}

--- a/src/ssort/_utils.py
+++ b/src/ssort/_utils.py
@@ -10,10 +10,7 @@ from typing import Any, Callable, Generic, TypeVar
 
 from ssort._exceptions import UnknownEncodingError
 
-if sys.version_info < (3, 9):
-    memoize = functools.lru_cache(maxsize=None)
-else:
-    memoize = functools.cache
+memoize = functools.cache
 
 
 def sort_key_from_iter(values):

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import sys
 from typing import Iterable
 
 import pytest
@@ -15,8 +14,7 @@ _deprecated_node_types: tuple[type[ast.AST], ...] = (
     ast.Suite,
 )
 
-if sys.version_info >= (3, 9):
-    _deprecated_node_types += (ast.Index, ast.ExtSlice)
+_deprecated_node_types += (ast.Index, ast.ExtSlice)
 
 _ignored_node_types: tuple[type[ast.AST], ...] = (
     ast.expr_context,

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -12,9 +12,9 @@ _deprecated_node_types: tuple[type[ast.AST], ...] = (
     ast.AugStore,
     ast.Param,
     ast.Suite,
+    ast.Index,
+    ast.ExtSlice,
 )
-
-_deprecated_node_types += (ast.Index, ast.ExtSlice)
 
 _ignored_node_types: tuple[type[ast.AST], ...] = (
     ast.expr_context,

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -934,7 +934,9 @@ def test_if_exp_bindings_walrus_alternate():
 
 
 def test_if_exp_bindings_walrus():
-    node = _parse("(a := subsequent()) if (b := predicate()) else (c := alternate())")
+    node = _parse(
+        "(a := subsequent()) if (b := predicate()) else (c := alternate())"
+    )
     assert list(get_bindings(node)) == ["b", "a", "c"]
 
 
@@ -1066,22 +1068,30 @@ def test_dict_comp_bindings_unpack():
 
 
 def test_dict_comp_bindings_walrus_key():
-    node = _parse("{(key := item[0]): item[1] for item in iterator if check(item)}")
+    node = _parse(
+        "{(key := item[0]): item[1] for item in iterator if check(item)}"
+    )
     assert list(get_bindings(node)) == ["key"]
 
 
 def test_dict_comp_bindings_walrus_value():
-    node = _parse("{item[0]: (value := item[1]) for item in iterator if check(item)}")
+    node = _parse(
+        "{item[0]: (value := item[1]) for item in iterator if check(item)}"
+    )
     assert list(get_bindings(node)) == ["value"]
 
 
 def test_dict_comp_bindings_walrus_iter():
-    node = _parse("{item[0]: item[1] for item in (it := iterator) if check(item)}")
+    node = _parse(
+        "{item[0]: item[1] for item in (it := iterator) if check(item)}"
+    )
     assert list(get_bindings(node)) == ["it"]
 
 
 def test_dict_comp_bindings_walrus_condition():
-    node = _parse("{item[0]: item[1] for item in iterator if (c := check(item))}")
+    node = _parse(
+        "{item[0]: item[1] for item in iterator if (c := check(item))}"
+    )
     assert list(get_bindings(node)) == ["c"]
 
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -6,13 +6,6 @@ import pytest
 
 from ssort._bindings import get_bindings
 
-# Most walrus operator syntax is valid in 3.8. Only use this decorator for the
-# rare cases where it is not.
-walrus_operator = pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="some walrus operator syntax is not valid prior to python 3.9",
-)
-
 
 match_statement = pytest.mark.skipif(
     sys.version_info < (3, 10),
@@ -35,10 +28,7 @@ def _parse(source):
     root = ast.parse(source)
     assert len(root.body) == 1
     node = root.body[0]
-    if sys.version_info >= (3, 9):
-        print(ast.dump(node, include_attributes=True, indent=2))
-    else:
-        print(ast.dump(node, include_attributes=True))
+    print(ast.dump(node, include_attributes=True, indent=2))
     return node
 
 
@@ -96,7 +86,6 @@ def test_function_def_bindings_walrus_type():
     ]
 
 
-@walrus_operator
 def test_function_def_bindings_walrus_decorator():
     node = _parse(
         """
@@ -165,7 +154,6 @@ def test_async_function_def_bindings_walrus_type():
     ]
 
 
-@walrus_operator
 def test_async_function_def_bindings_walrus_decorator():
     node = _parse(
         """
@@ -201,7 +189,6 @@ def test_class_def_bindings():
     assert list(get_bindings(node)) == ["ClassName"]
 
 
-@walrus_operator
 def test_class_def_bindings_walrus_decorator():
     node = _parse(
         """
@@ -1004,14 +991,8 @@ def test_set_bindings_unpack():
     assert list(get_bindings(node)) == []
 
 
-@walrus_operator
 def test_set_bindings_walrus():
     node = _parse("{a, {b := genb()}, c}")
-    assert list(get_bindings(node)) == ["b"]
-
-
-def test_set_bindings_walrus_py38():
-    node = _parse("{a, {(b := genb())}, c}")
     assert list(get_bindings(node)) == ["b"]
 
 

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -6,7 +6,6 @@ import pytest
 
 from ssort._bindings import get_bindings
 
-
 match_statement = pytest.mark.skipif(
     sys.version_info < (3, 10),
     reason="match statements were introduced in python 3.10",
@@ -935,9 +934,7 @@ def test_if_exp_bindings_walrus_alternate():
 
 
 def test_if_exp_bindings_walrus():
-    node = _parse(
-        "(a := subsequent()) if (b := predicate()) else (c := alternate())"
-    )
+    node = _parse("(a := subsequent()) if (b := predicate()) else (c := alternate())")
     assert list(get_bindings(node)) == ["b", "a", "c"]
 
 
@@ -1069,30 +1066,22 @@ def test_dict_comp_bindings_unpack():
 
 
 def test_dict_comp_bindings_walrus_key():
-    node = _parse(
-        "{(key := item[0]): item[1] for item in iterator if check(item)}"
-    )
+    node = _parse("{(key := item[0]): item[1] for item in iterator if check(item)}")
     assert list(get_bindings(node)) == ["key"]
 
 
 def test_dict_comp_bindings_walrus_value():
-    node = _parse(
-        "{item[0]: (value := item[1]) for item in iterator if check(item)}"
-    )
+    node = _parse("{item[0]: (value := item[1]) for item in iterator if check(item)}")
     assert list(get_bindings(node)) == ["value"]
 
 
 def test_dict_comp_bindings_walrus_iter():
-    node = _parse(
-        "{item[0]: item[1] for item in (it := iterator) if check(item)}"
-    )
+    node = _parse("{item[0]: item[1] for item in (it := iterator) if check(item)}")
     assert list(get_bindings(node)) == ["it"]
 
 
 def test_dict_comp_bindings_walrus_condition():
-    node = _parse(
-        "{item[0]: item[1] for item in iterator if (c := check(item))}"
-    )
+    node = _parse("{item[0]: item[1] for item in iterator if (c := check(item))}")
     assert list(get_bindings(node)) == ["c"]
 
 

--- a/tests/test_method_requirements.py
+++ b/tests/test_method_requirements.py
@@ -17,10 +17,7 @@ def _method_requirements(source):
     root = ast.parse(source)
     assert len(root.body) == 1
     node = root.body[0]
-    if sys.version_info >= (3, 9):
-        print(ast.dump(node, include_attributes=True, indent=2))
-    else:
-        print(ast.dump(node, include_attributes=True))
+    print(ast.dump(node, include_attributes=True, indent=2))
     return list(get_method_requirements(node))
 
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -27,10 +27,7 @@ def _parse(source):
     root = ast.parse(source)
     assert len(root.body) == 1
     node = root.body[0]
-    if sys.version_info >= (3, 9):
-        print(ast.dump(node, include_attributes=True, indent=2))
-    else:
-        print(ast.dump(node, include_attributes=True))
+    print(ast.dump(node, include_attributes=True, indent=2))
     return node
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312,black,isort,ssort,pyflakes,pylint,mypy
+envlist = py39,py310,py311,py312,black,isort,ssort,pyflakes,pylint,mypy
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
Removes support for Python 3.8, which became EOL on 2024-10-07:

https://peps.python.org/pep-0569/