### PR TITLE
Bump macosx version to 26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
-        runs-on: ["ubuntu-22.04", "windows-2022", "macos-13"]
+        runs-on: ["ubuntu-22.04", "windows-2022", "macos-26"]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
New hotness according to https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/